### PR TITLE
Issue #82: Remove currency pipe warning (browser console)

### DIFF
--- a/src/app/components/pages/history/history.component.html
+++ b/src/app/components/pages/history/history.component.html
@@ -24,7 +24,7 @@
           </div>
           <div class="-balance">
             <h4>{{ transaction.balance | number:'1.0-6' }} SKY</h4>
-            <p *ngIf="price">{{ transaction.balance * price | currency:'USD':true:'1.2-2' }}</p>
+            <p *ngIf="price">{{ transaction.balance * price | currency:'USD':symbol:'1.2-2' }}</p>
           </div>
         </div>
       </ng-container>

--- a/src/app/components/pages/history/transaction-detail/transaction-detail.component.html
+++ b/src/app/components/pages/history/transaction-detail/transaction-detail.component.html
@@ -7,7 +7,7 @@
       <img src="/assets/img/send-gold.png">
     </div>
     <h4>{{ transaction.balance }} SKY</h4>
-    <p *ngIf="price">{{ transaction.balance * price | currency:'USD':true:'1.2-2' }}</p>
+    <p *ngIf="price">{{ transaction.balance * price | currency:'USD':symbol:'1.2-2' }}</p>
   </div>
   <div class="-footer">
     <div class="-row">


### PR DESCRIPTION
Fixes #82 

Changes:
- update currency pipe option to remove warning (pages: history, transaction-detail)
