### PR TITLE
#72: Transactions are created without inputs, outputs and signatures

### DIFF
--- a/src/app/services/cipher.provider.ts
+++ b/src/app/services/cipher.provider.ts
@@ -1,4 +1,4 @@
-import { Address } from '../app.datatypes';
+import { Address, TransactionInput, TransactionOutput } from '../app.datatypes';
 
 declare var Cipher;
 
@@ -14,7 +14,7 @@ export class CipherProvider {
     };
   }
 
-  prepareTransaction(inputs: string, outputs: string): string {
+  prepareTransaction(inputs: TransactionInput[], outputs: TransactionOutput[]): string {
     return Cipher.PrepareTransaction(JSON.stringify(inputs), JSON.stringify(outputs));
   }
 }

--- a/src/app/services/wallet.service.spec.ts
+++ b/src/app/services/wallet.service.spec.ts
@@ -241,7 +241,7 @@ describe('WalletService', () => {
         .subscribe();
 
       expect(spyCipherProvider.prepareTransaction)
-        .toHaveBeenCalledWith(JSON.stringify(expectedTxInputs), JSON.stringify(expectedTxOutputs));
+        .toHaveBeenCalledWith(expectedTxInputs, expectedTxOutputs);
 
       expect(spyApiService.postTransaction)
         .toHaveBeenCalledWith('preparedTransaction');

--- a/src/app/services/wallet.service.ts
+++ b/src/app/services/wallet.service.ts
@@ -76,7 +76,7 @@ export class WalletService {
         });
       });
 
-      const rawTransaction = this.cipherProvider.prepareTransaction(JSON.stringify(txInputs), JSON.stringify(txOutputs));
+      const rawTransaction = this.cipherProvider.prepareTransaction(txInputs, txOutputs);
 
       return this.apiService.postTransaction(rawTransaction);
     });


### PR DESCRIPTION
Fixes #72: Transactions are created without inputs, outputs and signatures

Changes:
- JSON.stringify is being called only ones for the transaction's inputs and outputs for the Cipher.PrepareTransaction.
