### PR TITLE
Issue #87: Problems when trying to unlock a wallet with an incorrect seed

### DIFF
--- a/src/app/services/wallet.service.ts
+++ b/src/app/services/wallet.service.ts
@@ -96,11 +96,10 @@ export class WalletService {
   unlockWallet(wallet: Wallet, seed: string): Promise<void> {
     return new Promise<void>((resolve, reject) => {
       let currentSeed = this.ascii_to_hexa(seed);
-      wallet.seed = seed;
       wallet.addresses.forEach(address => {
         const fullAddress = this.cipherProvider.generateAddress(currentSeed);
         if (fullAddress.address !== address.address) {
-          return reject(new Error('Wrong seed'));
+          throw new Error('Wrong seed');
         }
         address.next_seed = fullAddress.next_seed;
         address.secret_key = fullAddress.secret_key;
@@ -108,6 +107,7 @@ export class WalletService {
         currentSeed = fullAddress.next_seed;
       });
 
+      wallet.seed = seed;
       this.updateWallet(wallet);
       return resolve();
     });


### PR DESCRIPTION
Fixes #87 

Changes:
- throw Error instead of reject Promise in case when seed is incorrect;
