### PR TITLE
Issue #112: The option to add an address should be always visible

### DIFF
--- a/e2e/wallets.e2e-spec.ts
+++ b/e2e/wallets.e2e-spec.ts
@@ -84,4 +84,17 @@ describe('Wallets', () => {
     page.navigateTo();
     expect<any>(page.canUnlock()).toEqual(true);
   });
+
+  it('should always display add new address button for the wallet', () => {
+    page.navigateTo();
+    expect<any>(page.showAddAddress()).toEqual(true);
+  });
+
+  it('should display unlock wallet component on add new address for locked wallet', () => {
+    expect<any>(page.showShowUnlockWallet()).toEqual(true);
+  });
+
+  it('should unlock wallet component on add new address for locked wallet', () => {
+    expect<any>(page.unlockWallet()).toEqual(true);
+  });
 });

--- a/e2e/wallets.po.ts
+++ b/e2e/wallets.po.ts
@@ -104,11 +104,11 @@ export class WalletsPage {
     const btnCreate = element(by.buttonText('Create'));
 
     label.clear();
-    label.sendKeys('Test wallet');
+    label.sendKeys('Test create wallet');
     seed.clear();
-    seed.sendKeys('skycoin-web-e2e-test-seed');
+    seed.sendKeys('skycoin-web-e2e-test-create-wallet-seed');
     confirm.clear();
-    confirm.sendKeys('skycoin-web-e2e-test-seed');
+    confirm.sendKeys('skycoin-web-e2e-test-create-wallet-seed');
     return btnCreate.isEnabled().then(status => {
       if (status) {
         btnCreate.click();
@@ -160,8 +160,9 @@ export class WalletsPage {
   }
 
   hideEmptyAddress() {
-    return element(by.css('.-btn-minus')).click().then(() => {
-      return element.all(by.css('.coins-column')).filter((address) => {
+    return element.all(by.css('.-btn-minus')).first().click().then(() => {
+      const parentWalletElement = element.all(by.css('.-wallet-detail')).first();
+      return parentWalletElement.all(by.css('.coins-column')).filter((address) => {
         return address.getText().then(value => {
           return value === '0';
         });
@@ -219,6 +220,30 @@ export class WalletsPage {
         return btnUnlock.click().then(() => {
           return true;
         });
+      });
+    });
+  }
+
+  showAddAddress() {
+    return element.all(by.css('.-expand.rotate-90')).first().click().then(() => {
+      return element(by.css('.btn-add-address')).isPresent();
+    });
+  }
+
+  showShowUnlockWallet() {
+    return element(by.css('.btn-add-address')).click().then(() => {
+      return element(by.css('app-unlock-wallet')).isPresent();
+    });
+  }
+
+  unlockWallet() {
+    const seed = element(by.css('[formcontrolname="seed"]'));
+    seed.clear();
+    seed.sendKeys('skycoin-web-e2e-test-seed');
+
+    return element(by.buttonText('Unlock')).click().then(() => {
+      return (element(by.css('app-unlock-wallet')).isPresent()).then((result) => {
+        return !result;
       });
     });
   }

--- a/src/app/components/pages/wallets/address-detail/wallet-detail.component.html
+++ b/src/app/components/pages/wallets/address-detail/wallet-detail.component.html
@@ -12,7 +12,7 @@
   </div>
 </ng-container>
 <div class="-actions">
-  <div class="-button" (click)="newAddress()" *ngIf="wallet.seed && wallet.addresses[wallet.addresses.length -1].next_seed">
+  <div class="-button" (click)="onAddNewAddress()">
     <div class="-btn-plus">
       <img src="../../../../../assets/img/plus-grey.png">
       <span>New Address</span>

--- a/src/app/components/pages/wallets/address-detail/wallet-detail.component.html
+++ b/src/app/components/pages/wallets/address-detail/wallet-detail.component.html
@@ -13,7 +13,7 @@
 </ng-container>
 <div class="-actions">
   <div class="-button" (click)="onAddNewAddress()">
-    <div class="-btn-plus">
+    <div class="-btn-plus btn-add-address">
       <img src="../../../../../assets/img/plus-grey.png">
       <span>New Address</span>
     </div>

--- a/src/app/components/pages/wallets/address-detail/wallet-detail.component.spec.ts
+++ b/src/app/components/pages/wallets/address-detail/wallet-detail.component.spec.ts
@@ -1,5 +1,5 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
-import { MatDialog } from '@angular/material';
+import { MatDialog, MatSnackBar } from '@angular/material';
 
 import { WalletDetailComponent } from './wallet-detail.component';
 import { WalletService } from '../../../../services/wallet.service';
@@ -16,7 +16,8 @@ describe('WalletDetailComponent', () => {
       declarations: [ WalletDetailComponent ],
       providers: [
         { provide: WalletService, useClass: MockWalletService },
-        { provide: MatDialog, useValue: {} }
+        { provide: MatDialog, useValue: {} },
+        { provide: MatSnackBar, useValue: {} }
       ]
     }).compileComponents();
   }));

--- a/src/app/components/pages/wallets/address-detail/wallet-detail.component.ts
+++ b/src/app/components/pages/wallets/address-detail/wallet-detail.component.ts
@@ -1,9 +1,12 @@
 import { Component, Input } from '@angular/core';
 import { MatDialog, MatDialogConfig } from '@angular/material/dialog';
+import { MatSnackBar, MatSnackBarConfig } from '@angular/material';
+
 import { Wallet } from '../../../../app.datatypes';
 import { WalletService } from '../../../../services/wallet.service';
 import { QrCodeComponent } from '../../../layout/qr-code/qr-code.component';
 import { ChangeNameComponent } from '../change-name/change-name.component';
+import { openUnlockWalletModal } from '../../../../utils/index';
 
 @Component({
   selector: 'app-wallet-detail',
@@ -16,6 +19,7 @@ export class WalletDetailComponent {
   constructor(
     private walletService: WalletService,
     private dialog: MatDialog,
+    private snackBar: MatSnackBar,
   ) {}
 
   showQr(address) {
@@ -31,8 +35,13 @@ export class WalletDetailComponent {
     this.dialog.open(ChangeNameComponent, config);
   }
 
-  newAddress() {
-    this.walletService.addAddress(this.wallet);
+  onAddNewAddress() {
+    if (!this.wallet.seed || !this.wallet.addresses[this.wallet.addresses.length - 1].next_seed) {
+      openUnlockWalletModal(this.wallet, this.dialog).componentInstance.onWalletUnlocked
+        .subscribe(() => this.addNewAddress());
+    } else {
+      this.addNewAddress();
+    }
   }
 
   toggleEmpty() {
@@ -61,5 +70,15 @@ export class WalletDetailComponent {
     setTimeout(() => {
       address.isCopying = false;
       }, 500);
+  }
+
+  private addNewAddress() {
+    try {
+      this.walletService.addAddress(this.wallet);
+    } catch (exception) {
+      const config = new MatSnackBarConfig();
+      config.duration = 5000;
+      this.snackBar.open(exception.message, null, config);
+    }
   }
 }

--- a/src/app/components/pages/wallets/unlock-wallet/unlock-wallet.component.ts
+++ b/src/app/components/pages/wallets/unlock-wallet/unlock-wallet.component.ts
@@ -20,7 +20,7 @@ export class UnlockWalletComponent implements OnInit {
     public dialogRef: MatDialogRef<UnlockWalletComponent>,
     private formBuilder: FormBuilder,
     private walletService: WalletService,
-    private snackbar: MatSnackBar,
+    private snackbar: MatSnackBar
   ) {}
 
   ngOnInit() {


### PR DESCRIPTION
Fixes #112 

Changes:
- The option to add an address is always visible
- Toaster notification added on failed attempt to add address to the wallet
- Unlock wallet modal appears on attempt to add address to locked wallet
- Unit tests has been adjusted
- e2e test has been added to cover additional logic
- broken e2e tests has been fixed (create wallet and hide empty addresses tests were broken)