### PR TITLE
Issue #111: Duplicate title

### DIFF
--- a/src/app/components/pages/settings/outputs/outputs.component.html
+++ b/src/app/components/pages/settings/outputs/outputs.component.html
@@ -1,7 +1,6 @@
 <div class="sky-container sky-container-grey">
   <app-header title="Outputs"></app-header>
   <div class="container">
-    <h3>Outputs</h3>
     <div class="-table">
       <div class="-headers">
         <div class="flex-fill">Address</div>

--- a/src/app/components/pages/settings/outputs/outputs.component.scss
+++ b/src/app/components/pages/settings/outputs/outputs.component.scss
@@ -26,7 +26,7 @@ h3 {
 .-table {
   border-radius: 15px;
   box-shadow: 0 0 2px 2px rgba(0, 0, 0, 0.01), 1px 1px 2px 2px rgba(0, 0, 0, 0.01);
-  margin: 0 30px;
+  margin: 30px 30px 0 30px;
 }
 
 .-output {

--- a/src/app/components/pages/settings/pending-transactions/pending-transactions.component.html
+++ b/src/app/components/pages/settings/pending-transactions/pending-transactions.component.html
@@ -1,7 +1,6 @@
 <div class="sky-container sky-container-grey">
   <app-header title="Pending Transactions"></app-header>
   <div class="container">
-    <h3>Pending Transactions</h3>
     <div class="-table">
       <div class="-headers">
         <div class="-width-150">Timestamp</div>

--- a/src/app/components/pages/settings/pending-transactions/pending-transactions.component.scss
+++ b/src/app/components/pages/settings/pending-transactions/pending-transactions.component.scss
@@ -26,7 +26,7 @@ h3 {
 .-table {
   border-radius: 15px;
   box-shadow: 0 0 2px 2px rgba(0, 0, 0, 0.01), 1px 1px 2px 2px rgba(0, 0, 0, 0.01);
-  margin: 0 30px;
+  margin: 30px 30px 0 30px;
 }
 
 .-transaction {


### PR DESCRIPTION
Fixes #111 

Changes:
- Remove redundant titles on the outputs and pending transactions pages.
