### PR TITLE
Issue #110: Show decimals was fixed

### DIFF
--- a/src/app/components/pages/settings/pending-transactions/pending-transactions.component.html
+++ b/src/app/components/pages/settings/pending-transactions/pending-transactions.component.html
@@ -11,7 +11,7 @@
         <div class="-width-150 -timestamp">
           <strong>{{ transaction.timestamp | dateTime }}</strong>
         </div>
-        <div class="-width-150 -amount">{{ transaction.amount }}</div>
+        <div class="-width-150 -amount">{{ (transaction.amount ? transaction.amount : 0) | number:'1.0-6' }}</div>
         <div class="flex-fill -txid">{{ transaction.txid }}</div>
       </div>
     </div>

--- a/src/app/components/pages/settings/pending-transactions/pending-transactions.component.ts
+++ b/src/app/components/pages/settings/pending-transactions/pending-transactions.component.ts
@@ -37,7 +37,7 @@ export class PendingTransactionsComponent implements OnInit {
     .map(transaction => {
       transaction.amount = transaction.outputs
         .map(output => output.coins >= 0 ? output.coins : 0)
-        .reduce((a, b) => a + parseInt(b, 10), 0);
+        .reduce((a, b) => a + parseFloat(b), 0);
       return transaction;
     });
   }


### PR DESCRIPTION
Fixes #110 

Changes:
- convert coins using `parseFloat()` instead of `parseInt()`;
- add pipe to show decimals on the page.
