### PR TITLE
Issue #122: [Important] Use /balance instead of /outputs in WalletService.loadBalances

### DIFF
--- a/src/app/app.datatypes.ts
+++ b/src/app/app.datatypes.ts
@@ -74,4 +74,18 @@ export interface Balance {
     coins: number;
     hours: number;
   };
+  addresses: {
+    [key: string]: AddressBalance
+  };
+}
+
+export interface AddressBalance {
+  confirmed: {
+    coins: number;
+    hours: number;
+  };
+  predicted: {
+    coins: number;
+    hours: number;
+  };
 }

--- a/src/app/services/wallet.service.spec.ts
+++ b/src/app/services/wallet.service.spec.ts
@@ -445,6 +445,18 @@ function createBalance(coins = 0, hours = 0): Balance {
     predicted: {
       coins: coins,
       hours: hours
+    },
+    addresses: {
+      'address': {
+        confirmed: {
+          coins: coins,
+          hours: hours
+        },
+        predicted: {
+          coins: coins,
+          hours: hours
+        }
+      }
     }
   };
 }


### PR DESCRIPTION
Fixes #122 

Changes:
- WalletService.loadBalances has been used instead of the calculation balance based on the outputs
- Balance interface  has been created
- Wallet service unit tests have been adjusted
