### PR TITLE
Issue #128: It is necessary to add a margin at the bottom of most pages

### DIFF
--- a/src/app/components/pages/history/history.component.scss
+++ b/src/app/components/pages/history/history.component.scss
@@ -4,7 +4,7 @@
   background-color: #fbfbfb;
   border-radius: 10px;
   box-shadow: 0 0 2px 2px rgba(0, 0, 0, 0.01), 1px 1px 2px 2px rgba(0, 0, 0, 0.01);
-  margin-top: 30px;
+  margin: 30px 0;
 }
 
 .-transaction {

--- a/src/app/components/pages/send-skycoin/send-skycoin.component.scss
+++ b/src/app/components/pages/send-skycoin/send-skycoin.component.scss
@@ -7,5 +7,5 @@
   border-radius: 10px;
   box-shadow: 0 0 2px 2px rgba(0, 0, 0, 0.01), 1px 1px 2px 2px rgba(0, 0, 0, 0.01);
   padding: 30px;
-  margin-top: 30px;
+  margin: 30px 0;
 }

--- a/src/app/components/pages/settings/blockchain/blockchain.component.scss
+++ b/src/app/components/pages/settings/blockchain/blockchain.component.scss
@@ -3,7 +3,7 @@
   border-radius: 10px;
   box-shadow: 0 0 2px 2px rgba(0, 0, 0, 0.01), 1px 1px 2px 2px rgba(0, 0, 0, 0.01);
   padding: 30px;
-  margin-top: 30px;
+  margin: 30px 0;
   font-size: 13px;
 
   .-keys {

--- a/src/app/components/pages/wallets/wallets.component.scss
+++ b/src/app/components/pages/wallets/wallets.component.scss
@@ -85,7 +85,6 @@
 }
 
 .action-buttons {
-  margin-bottom: 74px;
   padding: 40px 0 40px;
   text-align: center;
 


### PR DESCRIPTION
Fixes #128 

Changes:
- removed margin at the bottom (74px) from action-buttons css-class (wallets page);
- added margin at the bottom (30px) in the following pages: history, blockchain, sendskycoin
