### PR TITLE
Issue #138: Use /api/v1/ prefix for API endpoints

### DIFF
--- a/proxy.config.js
+++ b/proxy.config.js
@@ -1,9 +1,6 @@
 const PROXY_CONFIG = {
   "/api/*": {
     "target": "http://127.0.0.1:6420",
-    "pathRewrite": {
-      "^/api" : ""
-    },
     "secure": false,
     "logLevel": "debug",
     "bypass": function (req) {

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -1,4 +1,4 @@
 export const environment = {
   production: true,
-  nodeUrl: 'https://node.skycoin.net/api/',
+  nodeUrl: 'https://node.skycoin.net/api/v1/',
 };

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -1,4 +1,4 @@
 export const environment = {
   production: false,
-  nodeUrl: '/api/',
+  nodeUrl: '/api/v1/',
 };


### PR DESCRIPTION
Fixes #138 

Changes:
-  "/api/v1/" has been used for all the connections to the node
