### PR TITLE
Issue #141: WalletService.loadBalances() called twice

### DIFF
--- a/src/app/services/wallet.service.ts
+++ b/src/app/services/wallet.service.ts
@@ -33,7 +33,6 @@ export class WalletService {
     private cipherProvider: CipherProvider
   ) {
     this.loadWallets();
-    this.loadBalances();
   }
 
   get addresses(): Observable<any[]> {


### PR DESCRIPTION
Fixes #141

Changes:
- WalletService.loadBalances() method has been removed from the wallet service constructor, since in it being run after uploading all block chains.
