### PR TITLE
Issue #148: Add a transaction verification screen

### DIFF
--- a/src/app/app.datatypes.ts
+++ b/src/app/app.datatypes.ts
@@ -20,7 +20,6 @@ export interface Address {
 }
 
 export class Transaction {
-  balance: number;
   inputs: any[];
   outputs: any[];
   hoursSent?: number;
@@ -29,6 +28,7 @@ export class Transaction {
 
 export class NormalTransaction extends Transaction {
   txid: string;
+  balance: number;
   addresses: string[];
   timestamp: number;
   block: number;

--- a/src/app/app.datatypes.ts
+++ b/src/app/app.datatypes.ts
@@ -19,15 +19,26 @@ export interface Address {
 }
 
 export class Transaction {
-  addresses: string[];
   balance: number;
-  block: number;
-  confirmed: boolean;
   inputs: any[];
   outputs: any[];
-  timestamp: number;
-  txid: string;
+  hoursSent?: number;
+  hoursBurned?: number;
 }
+
+export class NormalTransaction extends Transaction {
+  txid: string;
+  addresses: string[];
+  timestamp: number;
+  block: number;
+  confirmed: boolean;
+}
+
+export class PreviewTransaction extends Transaction {
+  from: string;
+  to: string;
+}
+
 export interface Output {
   address: string;
   coins: number;
@@ -52,6 +63,9 @@ export interface GetOutputsRequestOutput {
 export class TransactionInput {
   hash: string;
   secret: string;
+  address?: string;
+  coins?: number;
+  calculated_hours?: number;
 }
 
 export class TransactionOutput {

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -106,8 +106,7 @@ import { TransactionInfoComponent } from './components/pages/send-skycoin/send-v
     WalletDetailComponent,
     SendFormComponent,
     SendVerifyComponent,
-    TransactionInfoComponent,
-    WalletDetailComponent
+    TransactionInfoComponent
   ],
   entryComponents: [
     AddDepositAddressComponent,

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -66,6 +66,9 @@ import { FeatureToggleModule } from 'ngx-feature-toggle';
 import { FeatureService } from './services/feature.service';
 import { AppService } from './services/app.service';
 import { NumberFieldDirective } from './directives/number-field.directive';
+import { SendFormComponent } from './components/pages/send-skycoin/send-form/send-form.component';
+import { SendVerifyComponent } from './components/pages/send-skycoin/send-verify/send-verify.component';
+import { TransactionInfoComponent } from './components/pages/send-skycoin/send-verify/transaction-info/transaction-info.component';
 
 @NgModule({
   declarations: [
@@ -101,6 +104,9 @@ import { NumberFieldDirective } from './directives/number-field.directive';
     UnlockWalletComponent,
     WalletsComponent,
     WalletDetailComponent,
+    SendFormComponent,
+    SendVerifyComponent,
+    TransactionInfoComponent
   ],
   entryComponents: [
     AddDepositAddressComponent,

--- a/src/app/components/layout/button/button.component.html
+++ b/src/app/components/layout/button/button.component.html
@@ -1,5 +1,5 @@
 <button mat-button type="submit" mat-raised-button color="primary" [disabled]="disabled && !emit ? true : false"
-        [matTooltip]="error ? error : null" (click)="onClick()" [ngClass]="{enabled: !disabled}">
+        [matTooltip]="error ? error : null" (click)="this.state !== 0 ? onClick() : null" [ngClass]="{enabled: !disabled}">
   <ng-content></ng-content>
   <mat-icon *ngIf="state === 1">done</mat-icon>
   <mat-icon *ngIf="state === 2">error</mat-icon>

--- a/src/app/components/layout/button/button.component.ts
+++ b/src/app/components/layout/button/button.component.ts
@@ -33,4 +33,9 @@ export class ButtonComponent {
     this.error = error['_body'];
     this.state = 2;
   }
+
+  resetState() {
+    this.state = null;
+    this.error = '';
+  }
 }

--- a/src/app/components/pages/send-skycoin/send-form/send-form.component.html
+++ b/src/app/components/pages/send-skycoin/send-form/send-form.component.html
@@ -1,0 +1,30 @@
+<div [formGroup]="form">
+  <div class="form-field">
+    <label for="wallet">Send from</label>
+    <select formControlName="wallet" id="wallet">
+      <option value="" selected>Select Wallet</option>
+      <option *ngFor="let wallet of wallets"
+              [disabled]="!wallet.balance || wallet.balance <= 0"
+              [ngValue]="wallet">
+        {{ wallet.label }} — {{ wallet.balance | number:'1.0-6' }} SKY
+      </option>
+    </select>
+  </div>
+
+  <div class="form-field">
+    <label for="address">Send to</label>
+    <input formControlName="address" id="address" placeholder="Recipient address">
+  </div>
+  <div class="form-field">
+    <label for="amount">Amount</label>
+    <input formControlName="amount" id="amount" placeholder="SKY" type="number">
+  </div>
+  <div class="form-field">
+    <label for="notes">Notes</label>
+    <input formControlName="notes" id="notes" placeholder="Your note here">
+  </div>
+
+  <app-button #button (action)="onVerify()" class="primary" [disabled]="!form.valid">
+    Verify
+  </app-button>
+</div>

--- a/src/app/components/pages/send-skycoin/send-form/send-form.component.html
+++ b/src/app/components/pages/send-skycoin/send-form/send-form.component.html
@@ -24,7 +24,7 @@
     <input formControlName="notes" id="notes" placeholder="Your note here">
   </div>
 
-  <app-button #button (action)="onVerify()" class="primary" [disabled]="!form.valid">
-    Verify
-  </app-button>
+  <div class="-buttons">
+    <app-button #button (action)="onVerify()" class="primary" [disabled]="!form.valid">Verify</app-button>
+  </div>
 </div>

--- a/src/app/components/pages/send-skycoin/send-form/send-form.component.scss
+++ b/src/app/components/pages/send-skycoin/send-form/send-form.component.scss
@@ -1,0 +1,7 @@
+app-button ::ng-deep button {
+  margin-bottom: 0;
+}
+
+.-buttons {
+  text-align: center;
+}

--- a/src/app/components/pages/send-skycoin/send-form/send-form.component.spec.ts
+++ b/src/app/components/pages/send-skycoin/send-form/send-form.component.spec.ts
@@ -1,0 +1,43 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { MatSnackBarModule, MatDialog } from '@angular/material';
+import { NO_ERRORS_SCHEMA } from '@angular/core';
+import { FormBuilder } from '@angular/forms';
+import { Observable } from 'rxjs/Observable';
+
+import { SendFormComponent } from './send-form.component';
+import { WalletService } from '../../../../services/wallet.service';
+import { Wallet } from '../../../../app.datatypes';
+
+class MockWalletService {
+  get all(): Observable<Wallet[]> {
+    return Observable.of([]);
+  }
+}
+
+describe('SendFormComponent', () => {
+  let component: SendFormComponent;
+  let fixture: ComponentFixture<SendFormComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ SendFormComponent ],
+      schemas: [ NO_ERRORS_SCHEMA ],
+      imports: [ MatSnackBarModule ],
+      providers: [
+        FormBuilder,
+        { provide: WalletService, useClass: MockWalletService },
+        { provide: MatDialog, useValue: {} }
+      ]
+    }).compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(SendFormComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/components/pages/send-skycoin/send-form/send-form.component.ts
+++ b/src/app/components/pages/send-skycoin/send-form/send-form.component.ts
@@ -1,0 +1,129 @@
+import { Component, EventEmitter, Input, OnDestroy, OnInit, Output, ViewChild } from '@angular/core';
+import { FormBuilder, FormControl, FormGroup, Validators } from '@angular/forms';
+import { MatDialog, MatSnackBar, MatSnackBarConfig } from '@angular/material';
+import { ISubscription } from 'rxjs/Subscription';
+import 'rxjs/add/operator/delay';
+import 'rxjs/add/operator/filter';
+
+import { WalletService } from '../../../../services/wallet.service';
+import { ButtonComponent } from '../../../layout/button/button.component';
+import { Wallet } from '../../../../app.datatypes';
+import { openUnlockWalletModal } from '../../../../utils/index';
+
+@Component({
+  selector: 'app-send-form',
+  templateUrl: './send-form.component.html',
+  styleUrls: ['./send-form.component.scss'],
+})
+export class SendFormComponent implements OnInit, OnDestroy {
+  @ViewChild('button') button: ButtonComponent;
+  @Input() formData: any;
+  @Output() onFormSubmitted = new EventEmitter<any>();
+
+  form: FormGroup;
+  wallets: Wallet[];
+  transactions = [];
+
+  private subscription: ISubscription;
+
+  constructor(
+    private formBuilder: FormBuilder,
+    private walletService: WalletService,
+    private snackbar: MatSnackBar,
+    private unlockDialog: MatDialog
+  ) {}
+
+  ngOnInit() {
+    this.initForm();
+
+    this.walletService.all
+      .subscribe(wallets => this.wallets = wallets);
+  }
+
+  ngOnDestroy() {
+    this.subscription.unsubscribe();
+  }
+
+  onVerify() {
+    this.snackbar.dismiss();
+    this.button.resetState();
+
+    const wallet = this.form.value.wallet;
+
+    if (!wallet.seed) {
+      openUnlockWalletModal(wallet, this.unlockDialog).componentInstance.onWalletUnlocked
+        .subscribe(() => this.createTransaction(wallet));
+    } else {
+      this.createTransaction(wallet);
+    }
+  }
+
+  private createTransaction(wallet: Wallet) {
+    this.button.setLoading();
+
+    this.walletService.createTransaction(wallet, this.form.value.address.replace(/\s/g, ''), this.form.value.amount)
+      .subscribe(
+        transaction => this.onTransactionCreated(transaction),
+        error => this.onError(error)
+      );
+  }
+
+  private onTransactionCreated(transaction) {
+    this.onFormSubmitted.emit({
+      wallet: this.form.value.wallet,
+      address: this.form.value.address,
+      amount: this.form.value.amount,
+      notes: this.form.value.notes,
+      transaction,
+    });
+  }
+
+  private onError(error) {
+    const config = new MatSnackBarConfig();
+    config.duration = 300000;
+    this.snackbar.open(error.message, null, config);
+    this.button.setError(error.message);
+  }
+
+  private initForm() {
+    this.form = this.formBuilder.group({
+      wallet: ['', Validators.required],
+      address: ['', Validators.required],
+      amount: ['', [Validators.required]],
+      notes: [''],
+    });
+
+    this.subscription = this.form.controls.wallet.valueChanges.subscribe(value => {
+      const balance = value && value.balance ? value.balance : 0;
+
+      this.form.controls.amount.setValidators([
+        Validators.required,
+        Validators.min(0.000001),
+        Validators.max(balance),
+        this.validateAmount,
+      ]);
+
+      this.form.controls.amount.updateValueAndValidity();
+    });
+
+    if (this.formData) {
+      Object.keys(this.form.controls).forEach(control => {
+        this.form.get(control).setValue(this.formData[control]);
+      });
+    }
+  }
+
+  private validateAmount(amountControl: FormControl) {
+    if (!amountControl.value || isNaN(amountControl.value) || parseFloat(amountControl.value) <= 0) {
+      return { Invalid: true };
+    }
+
+    const parts = amountControl.value.toString().split('.');
+
+    if (parts.length === 2 && parts[1].length > 6) {
+      return { Invalid: true };
+    }
+
+    return null;
+  }
+}

--- a/src/app/components/pages/send-skycoin/send-skycoin.component.html
+++ b/src/app/components/pages/send-skycoin/send-skycoin.component.html
@@ -1,35 +1,17 @@
 <div class="sky-container sky-container-grey">
   <app-header title="Wallets"></app-header>
   <div class="container">
-    <div [formGroup]="form" class="-paper">
-          <div class="form-field">
-            <label for="wallet">Send from</label>
-            <select formControlName="wallet" id="wallet">
-              <option value="" selected>Select Wallet</option>
-              <option *ngFor="let wallet of wallets"
-                      [disabled]="!wallet.balance || wallet.balance <= 0"
-                      [ngValue]="wallet">
-                {{ wallet.label }} — {{ wallet.balance | number:'1.0-6' }} SKY
-              </option>
-            </select>
-          </div>
-
-          <div class="form-field">
-            <label for="address">Send to</label>
-            <input formControlName="address" id="address" placeholder="Recipient address">
-          </div>
-          <div class="form-field">
-            <label for="amount">Amount</label>
-            <input formControlName="amount" id="amount" placeholder="SKY" type="number">
-          </div>
-          <div class="form-field">
-            <label for="notes">Notes</label>
-            <input formControlName="notes" id="notes" placeholder="Your note here">
-          </div>
-
-      <app-button #button (action)="onSendSkyCoin()" class="primary" [disabled]="!form.valid">
-        Send
-      </app-button>
+    <div class="-paper">
+      <app-send-form
+              *ngIf="showForm"
+              [formData]="formData"
+              (onFormSubmitted)="onFormSubmitted($event)">
+      </app-send-form>
+      <app-send-verify
+              *ngIf="!showForm"
+              [transaction]="transaction"
+              (onBack)="onBack($event)">
+      </app-send-verify>
     </div>
   </div>
 </div>

--- a/src/app/components/pages/send-skycoin/send-skycoin.component.spec.ts
+++ b/src/app/components/pages/send-skycoin/send-skycoin.component.spec.ts
@@ -1,18 +1,7 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { NO_ERRORS_SCHEMA } from '@angular/core';
-import { FormBuilder } from '@angular/forms';
-import { MatSnackBarModule, MatDialog } from '@angular/material';
 
 import { SendSkycoinComponent } from './send-skycoin.component';
-import { WalletService } from '../../../services/wallet.service';
-import { Observable } from 'rxjs/Observable';
-import { Wallet } from '../../../app.datatypes';
-
-class MockWalletService {
-  get all(): Observable<Wallet[]> {
-    return Observable.of([]);
-  }
-}
 
 describe('SendSkycoinComponent', () => {
   let component: SendSkycoinComponent;
@@ -21,13 +10,7 @@ describe('SendSkycoinComponent', () => {
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       declarations: [ SendSkycoinComponent ],
-      schemas: [ NO_ERRORS_SCHEMA ],
-      imports: [ MatSnackBarModule ],
-      providers: [
-        FormBuilder,
-        { provide: WalletService, useClass: MockWalletService },
-        { provide: MatDialog, useValue: {} }
-      ]
+      schemas: [ NO_ERRORS_SCHEMA ]
     }).compileComponents();
   }));
 

--- a/src/app/components/pages/send-skycoin/send-skycoin.component.ts
+++ b/src/app/components/pages/send-skycoin/send-skycoin.component.ts
@@ -1,99 +1,34 @@
-import { Component, OnInit, ViewChild } from '@angular/core';
-import { FormBuilder, FormGroup, Validators, FormControl } from '@angular/forms';
-import { MatSnackBar, MatSnackBarConfig } from '@angular/material/snack-bar';
-import 'rxjs/add/operator/delay';
-import 'rxjs/add/operator/filter';
-import { WalletService } from '../../../services/wallet.service';
-import { Wallet } from '../../../app.datatypes';
-import { MatDialog } from '@angular/material';
-import { openUnlockWalletModal } from '../../../utils/index';
+import { Component } from '@angular/core';
 
 @Component({
   selector: 'app-send-skycoin',
   templateUrl: './send-skycoin.component.html',
   styleUrls: ['./send-skycoin.component.scss'],
 })
-export class SendSkycoinComponent implements OnInit {
-  @ViewChild('button') button;
+export class SendSkycoinComponent {
+  showForm = true;
+  formData: any;
 
-  form: FormGroup;
-  wallets: Wallet[];
-  transactions = [];
-
-  constructor(
-    private formBuilder: FormBuilder,
-    private walletService: WalletService,
-    private snackbar: MatSnackBar,
-    private unlockDialog: MatDialog
-  ) { }
-
-  ngOnInit() {
-    this.initForm();
-
-    this.walletService.all
-      .subscribe(wallets => this.wallets = wallets);
+  onFormSubmitted(data) {
+    this.formData = data;
+    this.showForm = false;
   }
 
-  onSendSkyCoin() {
-    const wallet = this.form.value.wallet;
-
-    if (!wallet.seed) {
-      openUnlockWalletModal(wallet, this.unlockDialog).componentInstance.onWalletUnlocked
-        .subscribe(() => this.send(wallet));
-    } else {
-      this.send(wallet);
-    }
-  }
-
-  private send(wallet: Wallet) {
-    this.button.setLoading();
-    this.walletService.sendSkycoin(wallet, this.form.value.address.replace(/\s/g, ''), this.form.value.amount)
-      .subscribe(
-        () => {
-          this.form.reset({wallet: ''});
-          this.button.setSuccess();
-          this.walletService.loadBalances();
-        },
-        error => {
-          const config = new MatSnackBarConfig();
-          config.duration = 300000;
-          const errorMessage = error.message ? error.message : 'Your transaction appears to be unsuccessful';
-          this.snackbar.open(errorMessage, null, config);
-          this.button.setError(error);
-        },
-      );
-  }
-
-  private initForm() {
-    this.form = this.formBuilder.group({
-      wallet: ['', Validators.required],
-      address: ['', Validators.required],
-      amount: ['', [Validators.required]],
-      notes: [''],
-    });
-    this.form.controls.wallet.valueChanges.subscribe(value => {
-      const balance = value && value.balance ? value.balance : 0;
-      this.form.controls.amount.setValidators([
-        Validators.required,
-        Validators.min(0.000001),
-        Validators.max(balance),
-        this.validateAmount,
-      ]);
-      this.form.controls.amount.updateValueAndValidity();
-    });
-  }
-
-  private validateAmount(amountControl: FormControl) {
-    if (!amountControl.value || isNaN(amountControl.value) || parseFloat(amountControl.value) <= 0) {
-      return { Invalid: true };
+  onBack(deleteFormData) {
+    if (deleteFormData) {
+      this.formData = null;
     }
 
-    const parts = amountControl.value.toString().split('.');
+    this.showForm = true;
+  }
 
-    if (parts.length === 2 && parts[1].length > 6) {
-      return { Invalid: true };
-    }
+  get transaction() {
+    const transaction = this.formData.transaction;
 
-    return null;
+    transaction.from = this.formData.wallet.label;
+    transaction.to = this.formData.address;
+    transaction.balance = this.formData.amount;
+
+    return transaction;
   }
 }

--- a/src/app/components/pages/send-skycoin/send-verify/send-verify.component.html
+++ b/src/app/components/pages/send-skycoin/send-verify/send-verify.component.html
@@ -1,0 +1,9 @@
+<app-transaction-info
+  [transaction]="transaction"
+  [isPreview]="true"
+></app-transaction-info>
+
+<div class="-buttons">
+  <app-button #backButton (action)="back()">Back</app-button>
+  <app-button #sendButton (action)="send()" class="primary">Send</app-button>
+</div>

--- a/src/app/components/pages/send-skycoin/send-verify/send-verify.component.scss
+++ b/src/app/components/pages/send-skycoin/send-verify/send-verify.component.scss
@@ -1,0 +1,8 @@
+app-button ::ng-deep button {
+  margin-bottom: 0;
+}
+
+.-buttons {
+  margin-top: 10px;
+  text-align: center;
+}

--- a/src/app/components/pages/send-skycoin/send-verify/send-verify.component.spec.ts
+++ b/src/app/components/pages/send-skycoin/send-verify/send-verify.component.spec.ts
@@ -1,0 +1,37 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { MatSnackBar } from '@angular/material';
+import { NO_ERRORS_SCHEMA } from '@angular/core';
+
+import { SendVerifyComponent } from './send-verify.component';
+import { WalletService } from '../../../../services/wallet.service';
+
+class MockWalletService {
+}
+
+describe('SendVerifyComponent', () => {
+  let component: SendVerifyComponent;
+  let fixture: ComponentFixture<SendVerifyComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ SendVerifyComponent ],
+      schemas: [ NO_ERRORS_SCHEMA ],
+      providers: [
+        { provide: WalletService, useClass: MockWalletService },
+        { provide: MatSnackBar, useValue: {} }
+      ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(SendVerifyComponent);
+    component = fixture.componentInstance;
+    component.transaction = { balance: 0, inputs: [], outputs: [], from: '', to: '' };
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/components/pages/send-skycoin/send-verify/send-verify.component.spec.ts
+++ b/src/app/components/pages/send-skycoin/send-verify/send-verify.component.spec.ts
@@ -27,7 +27,7 @@ describe('SendVerifyComponent', () => {
   beforeEach(() => {
     fixture = TestBed.createComponent(SendVerifyComponent);
     component = fixture.componentInstance;
-    component.transaction = { balance: 0, inputs: [], outputs: [], from: '', to: '' };
+    component.transaction = { inputs: [], outputs: [], from: '', to: '' };
     fixture.detectChanges();
   });
 

--- a/src/app/components/pages/send-skycoin/send-verify/send-verify.component.ts
+++ b/src/app/components/pages/send-skycoin/send-verify/send-verify.component.ts
@@ -32,8 +32,6 @@ export class SendVerifyComponent {
         () => this.onSuccess(),
         (error) => this.onError(error)
       );
-
-    this.walletService.loadBalances();
   }
 
   back() {
@@ -42,6 +40,9 @@ export class SendVerifyComponent {
 
   private onSuccess() {
     this.sendButton.setSuccess();
+    this.sendButton.setDisabled();
+
+    this.walletService.loadBalances();
     setTimeout(() => this.onBack.emit(true), 3000);
   }
 

--- a/src/app/components/pages/send-skycoin/send-verify/send-verify.component.ts
+++ b/src/app/components/pages/send-skycoin/send-verify/send-verify.component.ts
@@ -1,0 +1,52 @@
+import { Component, EventEmitter, Input, Output, ViewChild } from '@angular/core';
+import { MatSnackBar, MatSnackBarConfig } from '@angular/material';
+
+import { PreviewTransaction } from '../../../../app.datatypes';
+import { WalletService } from '../../../../services/wallet.service';
+import { ButtonComponent } from '../../../layout/button/button.component';
+
+@Component({
+  selector: 'app-send-verify',
+  templateUrl: './send-verify.component.html',
+  styleUrls: ['./send-verify.component.scss'],
+})
+export class SendVerifyComponent {
+  @ViewChild('sendButton') sendButton: ButtonComponent;
+  @ViewChild('backButton') backButton: ButtonComponent;
+  @Input() transaction: PreviewTransaction;
+  @Output() onBack = new EventEmitter<boolean>();
+
+  constructor(
+    private walletService: WalletService,
+    private snackbar: MatSnackBar
+  ) {}
+
+  send() {
+    this.snackbar.dismiss();
+    this.sendButton.resetState();
+    this.sendButton.setLoading();
+
+    this.walletService.injectTransaction(this.transaction.inputs, this.transaction.outputs)
+      .subscribe(
+        () => this.onSuccess(),
+        (error) => this.onError(error)
+      );
+  }
+
+  back() {
+    this.onBack.emit(false);
+  }
+
+  private onSuccess() {
+    this.sendButton.setSuccess();
+    this.walletService.loadBalances();
+    this.onBack.emit(true);
+  }
+
+  private onError(error) {
+    const config = new MatSnackBarConfig();
+    config.duration = 300000;
+    this.snackbar.open(error.message, null, config);
+    this.sendButton.setError(error.message);
+  }
+}

--- a/src/app/components/pages/send-skycoin/send-verify/transaction-info/transaction-info.component.html
+++ b/src/app/components/pages/send-skycoin/send-verify/transaction-info/transaction-info.component.html
@@ -1,0 +1,85 @@
+<div class="row">
+  <div class="col-md-12">
+    <h4 *ngIf="isPreview">Confirm Transaction</h4>
+    <h4 *ngIf="!isPreview">Transaction</h4>
+
+    <div class="row">
+      <div class="col-md-8 -tx-meta">
+        <ng-container *ngIf="isPreview">
+          <div class="-data">
+            <span>From:</span> {{ transaction.from }}
+          </div>
+          <div class="-data">
+            <span>To:</span> {{ transaction.to }}
+          </div>
+        </ng-container>
+        <ng-container *ngIf="!isPreview">
+          <div class="-data">
+            <span>Date:</span> {{ transaction.timestamp * 1000 | date:'short' }}
+          </div>
+          <div class="-data">
+            <span>Status:</span> {{ transaction.confirmed ? 'Confirmed' : 'Pending' }}
+          </div>
+        </ng-container>
+        <div class="-data">
+          <span>Coins:</span> {{ transaction.balance | number:'1.0-6' }}
+        </div>
+        <div class="-data" *ngIf="isPreview">
+          <span>Hours:</span>
+          {{ transaction.hoursSent | number:'1.0-6' }} sent
+          |
+          {{ transaction.hoursBurned | number:'1.0-6' }} burned
+        </div>
+        <div class="-data -more" *ngIf="!showInputsOutputs">
+          <span (click)="toggleInputsOutputs($event)">
+            Show more <mat-icon>keyboard_arrow_down</mat-icon>
+          </span>
+        </div>
+      </div>
+
+      <div class="col-md-4 -tx-price">
+        <div class="-icon" [ngClass]="{ '-incoming': !isPreview && transaction.balance > 0 }">
+          <img src="/assets/img/send-blue.png">
+        </div>
+        <h4>{{ transaction.balance | number:'1.0-6' }} SKY</h4>
+        <p *ngIf="price" [matTooltip]="!isPreview ? 'Calculated at the current rate' : ''">
+          {{ transaction.balance * price | currency:'USD':'symbol':'1.2-2' }}<span *ngIf="!isPreview">*</span>
+        </p>
+      </div>
+    </div>
+  </div>
+  <ng-container *ngIf="showInputsOutputs">
+    <div class="col-md-6 -margin-top">
+      <h4>Inputs</h4>
+
+      <div class="-item" *ngFor="let input of transaction.inputs; let i = index">
+        <div class="-number">{{ i + 1 }}</div>
+        <div class="-info">
+          <div class="-address">{{ isPreview ? input.address : input.owner }}</div>
+          <div class="-data">
+            <span>Coins:</span> {{ input.coins | number:'1.0-6' }}
+          </div>
+          <div class="-data" *ngIf="isPreview">
+            <span>Hours:</span> {{ input.calculated_hours | number:'1.0-6' }}
+          </div>
+        </div>
+      </div>
+    </div>
+    <div class="col-md-6 -margin-top">
+      <h4>Outputs</h4>
+
+      <div class="-item" *ngFor="let output of transaction.outputs; let i = index">
+        <div class="-number">{{ i + 1 }}</div>
+        <div class="-info">
+          <div class="-address">{{ isPreview ? output.address : output.dst }}</div>
+          <div class="-data">
+            <span>Coins:</span> {{ output.coins | number:'1.0-6' }}
+          </div>
+          <div class="-data" *ngIf="isPreview">
+            <span>Hours:</span> {{ output.hours | number:'1.0-6' }}
+          </div>
+        </div>
+      </div>
+    </div>
+  </ng-container>
+</div>

--- a/src/app/components/pages/send-skycoin/send-verify/transaction-info/transaction-info.component.scss
+++ b/src/app/components/pages/send-skycoin/send-verify/transaction-info/transaction-info.component.scss
@@ -1,0 +1,105 @@
+@import '../../../../../../theme/variables';
+
+h4 {
+  font-size: 14px;
+  margin: 0 0 30px;
+}
+
+.-item {
+  display: flex;
+  font-size: 13px;
+
+  &:not(:last-child) {
+    margin-bottom: 10px;
+  }
+
+  .-number {
+    padding: 10px;
+    background: $grey-light;
+    align-self: flex-start;
+    border-radius: 10px;
+  }
+
+  .-info {
+    margin-left: 10px;
+    display: flex;
+    flex-direction: column;
+
+    .-address {
+      padding: 10px 0;
+      margin-bottom: 5px;
+    }
+  }
+}
+
+.-data {
+  font-size: 12px;
+
+  &:not(:last-child) {
+    margin-bottom: 5px;
+  }
+
+  span:first-child {
+    color: $grey-dark;
+    display: inline-block;
+    width: 60px;
+  }
+
+  &.-more {
+    margin-bottom: 0 !important;
+
+    span {
+      width: auto !important;
+      margin-top: 20px;
+      color: $gradient-blue-dark;
+      cursor: pointer;
+
+      mat-icon {
+        display: inline;
+        vertical-align: middle;
+        font-size: 13px;
+      }
+    }
+  }
+}
+
+.-tx-meta {
+  .-data {
+    margin-bottom: 10px;
+  }
+}
+
+.-tx-price {
+  text-align: center;
+
+  .-icon {
+    &.-incoming {
+      transform: rotate(180deg);
+    }
+
+    img {
+      width: 30px;
+    }
+  }
+
+  h4 {
+    color: $grey-normal;
+    font-size: 16px;
+    font-weight: 700;
+    margin: 10px 0 5px;
+  }
+
+  p {
+    color: $grey-dark;
+    font-size: 12px;
+    margin: 0;
+
+    span {
+      color: lighten($grey-dark, 40%);
+    }
+  }
+}
+
+.-margin-top {
+  margin-top: 30px;
+}

--- a/src/app/components/pages/send-skycoin/send-verify/transaction-info/transaction-info.component.spec.ts
+++ b/src/app/components/pages/send-skycoin/send-verify/transaction-info/transaction-info.component.spec.ts
@@ -1,0 +1,38 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { NO_ERRORS_SCHEMA } from '@angular/core';
+import { Subject } from 'rxjs/Subject';
+import { BehaviorSubject } from 'rxjs/BehaviorSubject';
+
+import { TransactionInfoComponent } from './transaction-info.component';
+import { PriceService } from '../../../../../services/price.service';
+
+class MockPriceService {
+  price: Subject<number> = new BehaviorSubject<number>(null);
+}
+
+describe('TransactionInfoComponent', () => {
+  let component: TransactionInfoComponent;
+  let fixture: ComponentFixture<TransactionInfoComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ TransactionInfoComponent ],
+      schemas: [ NO_ERRORS_SCHEMA ],
+      providers: [
+        { provide: PriceService, useClass: MockPriceService }
+      ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(TransactionInfoComponent);
+    component = fixture.componentInstance;
+    component.transaction = { balance: 0, inputs: [], outputs: [] };
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/components/pages/send-skycoin/send-verify/transaction-info/transaction-info.component.spec.ts
+++ b/src/app/components/pages/send-skycoin/send-verify/transaction-info/transaction-info.component.spec.ts
@@ -28,7 +28,7 @@ describe('TransactionInfoComponent', () => {
   beforeEach(() => {
     fixture = TestBed.createComponent(TransactionInfoComponent);
     component = fixture.componentInstance;
-    component.transaction = { balance: 0, inputs: [], outputs: [] };
+    component.transaction = { inputs: [], outputs: [] };
     fixture.detectChanges();
   });
 

--- a/src/app/components/pages/send-skycoin/send-verify/transaction-info/transaction-info.component.ts
+++ b/src/app/components/pages/send-skycoin/send-verify/transaction-info/transaction-info.component.ts
@@ -1,0 +1,44 @@
+import { Component, Input, OnDestroy, OnInit } from '@angular/core';
+import { ISubscription } from 'rxjs/Subscription';
+
+import { PreviewTransaction, Transaction } from '../../../../../app.datatypes';
+import { PriceService } from '../../../../../services/price.service';
+
+@Component({
+  selector: 'app-transaction-info',
+  templateUrl: './transaction-info.component.html',
+  styleUrls: ['./transaction-info.component.scss'],
+})
+export class TransactionInfoComponent implements OnInit, OnDestroy {
+  @Input() transaction: Transaction;
+  @Input() isPreview: boolean;
+  price: number;
+  showInputsOutputs = false;
+
+  private subscription: ISubscription;
+
+  constructor(private priceService: PriceService) {
+  }
+
+  ngOnInit() {
+    this.subscription = this.priceService.price
+      .subscribe(price => this.price = price);
+
+    if (this.isPreview) {
+      this.transaction.hoursSent = this.transaction.outputs
+        .filter(o => o.address === (<PreviewTransaction> this.transaction).to)
+        .map(o => parseInt(o.hours, 10))
+        .reduce((a, b) => a + b, 0);
+    }
+  }
+
+  ngOnDestroy() {
+    this.subscription.unsubscribe();
+  }
+
+  toggleInputsOutputs(event) {
+    event.preventDefault();
+
+    this.showInputsOutputs = !this.showInputsOutputs;
+  }
+}

--- a/src/app/components/pages/send-skycoin/send-verify/transaction-info/transaction-info.component.ts
+++ b/src/app/components/pages/send-skycoin/send-verify/transaction-info/transaction-info.component.ts
@@ -23,13 +23,6 @@ export class TransactionInfoComponent implements OnInit, OnDestroy {
   ngOnInit() {
     this.subscription = this.priceService.price
       .subscribe(price => this.price = price);
-
-    if (this.isPreview) {
-      this.transaction.hoursSent = this.transaction.outputs
-        .filter(o => o.address === (<PreviewTransaction> this.transaction).to)
-        .map(o => parseInt(o.hours, 10))
-        .reduce((a, b) => a + b, 0);
-    }
   }
 
   ngOnDestroy() {

--- a/src/app/services/wallet.service.spec.ts
+++ b/src/app/services/wallet.service.spec.ts
@@ -5,7 +5,7 @@ import { BehaviorSubject } from 'rxjs/BehaviorSubject';
 import { WalletService } from './wallet.service';
 import { ApiService } from './api.service';
 import { CipherProvider } from './cipher.provider';
-import { Wallet, Address, Transaction, TransactionOutput, TransactionInput, Output, Balance } from '../app.datatypes';
+import { Wallet, Address, NormalTransaction, TransactionOutput, TransactionInput, Output, Balance } from '../app.datatypes';
 
 describe('WalletService', () => {
   let store = {};
@@ -174,7 +174,7 @@ describe('WalletService', () => {
       spyApiService.get.and.returnValue( Observable.of([apiResponse]) );
 
       walletService.retrieveAddressTransactions( createAddress() )
-        .subscribe((transactions: Transaction[]) => {
+        .subscribe((transactions: NormalTransaction[]) => {
           expect(transactions).toEqual([expectedTransaction]);
         });
     }));
@@ -189,7 +189,7 @@ describe('WalletService', () => {
       const apiResponse = createAddressTransactions(ownerAddress.address, destinationAddress, 13);
       spyApiService.get.and.returnValue( Observable.of([apiResponse]) );
 
-      const expectedTransaction: Transaction = createTransaction([destinationAddress], ownerAddress.address, destinationAddress, 13, -13);
+      const expectedTransaction: NormalTransaction = createTransaction([destinationAddress], ownerAddress.address, destinationAddress, 13, -13);
 
       walletService.transactions()
         .subscribe((transactions: any[]) => {
@@ -205,7 +205,7 @@ describe('WalletService', () => {
       const apiResponse = createAddressTransactions(ownerAddress, destinationAddress.address, 13);
       spyApiService.get.and.returnValue( Observable.of([apiResponse]) );
 
-      const expectedTransaction: Transaction = createTransaction([destinationAddress.address], ownerAddress, destinationAddress.address, 13, 13);
+      const expectedTransaction: NormalTransaction = createTransaction([destinationAddress.address], ownerAddress, destinationAddress.address, 13, 13);
 
       walletService.transactions()
         .subscribe((transactions: any[]) => {
@@ -421,7 +421,7 @@ function createAddressTransactions(ownerAddress: string, destinationAddress: str
   };
 }
 
-function createTransaction(addresses: string[], ownerAddress: string, destinationAddress: string, coins: number = 0, balance: number = 0): Transaction {
+function createTransaction(addresses: string[], ownerAddress: string, destinationAddress: string, coins: number = 0, balance: number = 0): NormalTransaction {
   return {
     addresses: addresses,
     balance: balance,

--- a/src/app/services/wallet.service.ts
+++ b/src/app/services/wallet.service.ts
@@ -12,7 +12,7 @@ import { ReplaySubject } from 'rxjs/ReplaySubject';
 
 import { ApiService } from './api.service';
 import { CipherProvider } from './cipher.provider';
-import { Address, Output, Transaction, TransactionInput, TransactionOutput,
+import { Address, Output, NormalTransaction, TransactionInput, TransactionOutput,
   Wallet, TotalBalance, GetOutputsRequestOutput, Balance } from '../app.datatypes';
 
 @Injectable()
@@ -30,6 +30,7 @@ export class WalletService {
 
   private readonly allocationRatio = 0.25;
   private readonly unburnedHoursRatio = 0.5;
+  private readonly coinsMultiplier = 1000000;
 
   constructor(
     private apiService: ApiService,
@@ -115,6 +116,62 @@ export class WalletService {
     });
   }
 
+  createTransaction(wallet: Wallet, address: string, amount: number): Observable<{ inputs: TransactionInput[], outputs: TransactionOutput[] }> {
+    const addresses = wallet.addresses.map(a => a.address).join(',');
+
+    return this.apiService.getOutputs(addresses)
+      .flatMap((outputs: Output[]) => {
+        const minRequiredOutputs =  this.getMinRequiredOutputs(amount, outputs);
+        const totalCoins = parseInt((minRequiredOutputs.reduce((count, output) => count + output.coins, 0)) + '', 10);
+
+        if (totalCoins < amount) {
+          throw new Error('Not enough available SKY Hours to perform transaction!');
+        }
+
+        const totalHours = parseInt((minRequiredOutputs.reduce((count, output) => count + output.calculated_hours, 0)) + '', 10);
+        let hoursToSend = parseInt((totalHours * this.allocationRatio) + '', 10);
+
+        const txOutputs: TransactionOutput[] = [];
+        const txInputs: TransactionInput[] = [];
+        const calculatedHours = parseInt((totalHours * this.unburnedHoursRatio) + '', 10);
+
+        const changeCoins = totalCoins - amount;
+
+        if (changeCoins > 0) {
+          txOutputs.push({
+            address: wallet.addresses[0].address,
+            coins: changeCoins,
+            hours: calculatedHours - hoursToSend
+          });
+        } else {
+          hoursToSend = calculatedHours;
+        }
+
+        txOutputs.push({ address: address, coins: amount, hours: hoursToSend });
+
+        minRequiredOutputs.forEach(input => {
+          txInputs.push({
+            hash: input.hash,
+            secret: wallet.addresses.find(a => a.address === input.address).secret_key,
+            address: input.address,
+            calculated_hours: input.calculated_hours,
+            coins: input.coins
+          });
+        });
+
+        return Observable.of({ inputs: txInputs, outputs: txOutputs });
+    });
+  }
+
+  injectTransaction(txInputs: TransactionInput[], txOutputs: TransactionOutput[]): Observable<string> {
+    txOutputs.forEach(output => {
+      output.coins = output.coins * this.coinsMultiplier;
+    });
+
+    const rawTransaction = this.cipherProvider.prepareTransaction(txInputs, txOutputs);
+    return this.apiService.postTransaction(rawTransaction);
+  }
+
   updateWallet(wallet: Wallet) {
     this.all.first().subscribe(wallets => {
       const index = wallets.findIndex(w => w.addresses[0].address === wallet.addresses[0].address);
@@ -179,7 +236,7 @@ export class WalletService {
       }));
   }
 
-  retrieveAddressTransactions(address: Address): Observable<Transaction[]> {
+  retrieveAddressTransactions(address: Address): Observable<NormalTransaction[]> {
     return this.apiService.get('explorer/address', { address: address.address })
       .map(transactions => transactions.map(transaction => ({
         addresses: [],
@@ -221,7 +278,7 @@ export class WalletService {
               wallets.map((wallet: Wallet) => {
                 wallet.addresses.map((address: Address) => {
                   if (balance.addresses[address.address]) {
-                    address.balance = balance.addresses[address.address].confirmed.coins / 1000000;
+                    address.balance = balance.addresses[address.address].confirmed.coins / this.coinsMultiplier;
                     address.hours = balance.addresses[address.address].confirmed.hours;
                   }
                 });

--- a/src/app/services/wallet.service.ts
+++ b/src/app/services/wallet.service.ts
@@ -14,7 +14,7 @@ import { ReplaySubject } from 'rxjs/ReplaySubject';
 import { ApiService } from './api.service';
 import { CipherProvider } from './cipher.provider';
 import { Address, Output, NormalTransaction, TransactionInput, TransactionOutput,
-  Wallet, TotalBalance, GetOutputsRequestOutput, Balance } from '../app.datatypes';
+  Wallet, TotalBalance, GetOutputsRequestOutput, Balance, Transaction } from '../app.datatypes';
 
 @Injectable()
 export class WalletService {
@@ -117,7 +117,7 @@ export class WalletService {
     });
   }
 
-  createTransaction(wallet: Wallet, address: string, amount: number): Observable<{ inputs: TransactionInput[], outputs: TransactionOutput[] }> {
+  createTransaction(wallet: Wallet, address: string, amount: number): Observable<Transaction> {
     const addresses = wallet.addresses.map(a => a.address).join(',');
 
     return this.apiService.getOutputs(addresses)
@@ -160,7 +160,12 @@ export class WalletService {
           });
         });
 
-        return Observable.of({ inputs: txInputs, outputs: txOutputs });
+        return Observable.of({
+          inputs: txInputs,
+          outputs: txOutputs,
+          hoursSent: hoursToSend,
+          hoursBurned: totalHours - calculatedHours
+        });
     });
   }
 


### PR DESCRIPTION
Fixes #148 

Changes:
- splitted up the sendSkycoin method into two separate methods: createTransaction() and injectTransaction();
- added three new components: SendForm, SendVerify, TransactionInfo
- verification page is shown before actual sending of coins;
- added two separate data types: NormalTransaction and PreviewTransaction (both of them extends Transaction);
- 100000 multiplier is used when transaction is going to be posted (not in createTransaction);
- updated balance after transaction has been posted;
- added/updated appropriate unit tests;
