### PR TITLE
#174: The dates on the history page are barely visible

### DIFF
--- a/src/app/components/pages/history/history.component.scss
+++ b/src/app/components/pages/history/history.component.scss
@@ -74,7 +74,7 @@
       }
 
       .-timestamp {
-        color: rgba(30, 34, 39, 0.2);
+        color: rgba(30, 34, 39, 0.35);
       }
     }
 


### PR DESCRIPTION
Fixes #174

Changes:
- colour opacity of the dates on the history page.
