### PR TITLE
#172: Prevent the user from adding more than one wallet with the same seed

### DIFF
--- a/e2e/wallets.po.ts
+++ b/e2e/wallets.po.ts
@@ -125,7 +125,7 @@ export class WalletsPage {
     label.clear();
     label.sendKeys('Test load wallet');
     seed.clear();
-    seed.sendKeys('skycoin-web-e2e-test-seed');
+    seed.sendKeys('skycoin-web-e2e-test-load-wallet-seed');
     return btnLoad.isEnabled().then(status => {
       if (status) {
         btnLoad.click();

--- a/src/app/components/pages/onboarding/onboarding-create-wallet/onboarding-create-wallet.component.spec.ts
+++ b/src/app/components/pages/onboarding/onboarding-create-wallet/onboarding-create-wallet.component.spec.ts
@@ -1,6 +1,6 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { NO_ERRORS_SCHEMA } from '@angular/core';
-import { MatDialogModule } from '@angular/material';
+import { MatDialogModule, MatSnackBarModule } from '@angular/material';
 import { RouterTestingModule } from '@angular/router/testing';
 import { FormBuilder } from '@angular/forms';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
@@ -29,7 +29,8 @@ describe('OnboardingCreateWalletComponent', () => {
       imports: [
         MatDialogModule,
         RouterTestingModule,
-        BrowserAnimationsModule
+        BrowserAnimationsModule,
+        MatSnackBarModule
       ],
       providers: [
         FormBuilder,

--- a/src/app/components/pages/onboarding/onboarding-create-wallet/onboarding-create-wallet.component.ts
+++ b/src/app/components/pages/onboarding/onboarding-create-wallet/onboarding-create-wallet.component.ts
@@ -93,13 +93,13 @@ export class OnboardingCreateWalletComponent implements OnInit {
   }
 
   createWallet() {
-    this.walletService.create(this.form.value.label, this.form.value.seed);
-    this.showSafe();
+    this.walletService.create(this.form.value.label, this.form.value.seed)
+      .then(() => this.showSafe());
   }
 
   loadWallet() {
-    this.walletService.create(this.form.value.label, this.form.value.seed);
-    this.skip();
+    this.walletService.create(this.form.value.label, this.form.value.seed)
+      .then(() => this.skip());
   }
 
   skip() {

--- a/src/app/components/pages/onboarding/onboarding-create-wallet/onboarding-create-wallet.component.ts
+++ b/src/app/components/pages/onboarding/onboarding-create-wallet/onboarding-create-wallet.component.ts
@@ -2,6 +2,7 @@ import { Component, OnInit } from '@angular/core';
 import { FormBuilder, FormControl, FormGroup, Validators } from '@angular/forms';
 import { MatDialog, MatDialogConfig } from '@angular/material/dialog';
 import { Router } from '@angular/router';
+import { MatSnackBarConfig, MatSnackBar } from '@angular/material';
 import * as Bip39 from 'bip39';
 
 import { WalletService } from '../../../../services/wallet.service';
@@ -25,6 +26,7 @@ export class OnboardingCreateWalletComponent implements OnInit {
     private walletService: WalletService,
     private router: Router,
     private formBuilder: FormBuilder,
+    private snackBar: MatSnackBar
   ) { }
 
   ngOnInit() {
@@ -83,14 +85,12 @@ export class OnboardingCreateWalletComponent implements OnInit {
     this.dialog.open(OnboardingSafeguardComponent, this.createDialogConfig()).afterClosed().subscribe(result => {
       if (result) {
         this.createWallet();
-        this.skip();
       }
     });
   }
 
   loadWallet() {
-    this.walletService.create(this.form.value.label, this.form.value.seed)
-      .then(() => this.skip());
+    this.createWallet();
   }
 
   skip() {
@@ -102,12 +102,22 @@ export class OnboardingCreateWalletComponent implements OnInit {
   }
 
   private createWallet() {
-    this.walletService.create(this.form.value.label, this.form.value.seed);
+    this.walletService.create(this.form.value.label, this.form.value.seed)
+    .then(
+      () => this.skip(),
+      (error) => this.onCreateError(error.message)
+    );
   }
 
   private seedMatchValidator(g: FormGroup) {
       return g.get('seed').value === g.get('confirm_seed').value
         ? null : { mismatch: true };
+  }
+
+  private onCreateError(errorMesasge: string) {
+    const config = new MatSnackBarConfig();
+    config.duration = 5000;
+    this.snackBar.open(errorMesasge, null, config);
   }
 
   private createDialogConfig() {

--- a/src/app/components/pages/wallets/create-wallet/create-wallet.component.spec.ts
+++ b/src/app/components/pages/wallets/create-wallet/create-wallet.component.spec.ts
@@ -1,7 +1,7 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { NO_ERRORS_SCHEMA } from '@angular/core';
 import { FormBuilder } from '@angular/forms';
-import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material';
+import { MAT_DIALOG_DATA, MatDialogRef, MatSnackBarModule } from '@angular/material';
 
 import { CreateWalletComponent } from './create-wallet.component';
 import { WalletService } from '../../../../services/wallet.service';
@@ -16,6 +16,7 @@ describe('CreateWalletComponent', () => {
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       declarations: [ CreateWalletComponent ],
+      imports: [ MatSnackBarModule ],
       schemas: [ NO_ERRORS_SCHEMA ],
       providers: [
         FormBuilder,

--- a/src/app/components/pages/wallets/create-wallet/create-wallet.component.ts
+++ b/src/app/components/pages/wallets/create-wallet/create-wallet.component.ts
@@ -2,9 +2,9 @@ import { Component, Inject, OnInit } from '@angular/core';
 import { FormBuilder, FormControl, FormGroup, Validators } from '@angular/forms';
 import { MatDialogRef } from '@angular/material/dialog';
 import * as Bip39 from 'bip39';
+import { MAT_DIALOG_DATA, MatSnackBarConfig, MatSnackBar } from '@angular/material';
 
 import { WalletService } from '../../../../services/wallet.service';
-import { MAT_DIALOG_DATA } from '@angular/material';
 
 @Component({
   selector: 'app-create-wallet',
@@ -20,6 +20,7 @@ export class CreateWalletComponent implements OnInit {
     public dialogRef: MatDialogRef<CreateWalletComponent>,
     private walletService: WalletService,
     private formBuilder: FormBuilder,
+    private snackBar: MatSnackBar
   ) { }
 
   ngOnInit() {
@@ -31,12 +32,21 @@ export class CreateWalletComponent implements OnInit {
   }
 
   createWallet() {
-    this.walletService.create(this.form.value.label, this.form.value.seed);
-    this.dialogRef.close();
+    this.walletService.create(this.form.value.label, this.form.value.seed)
+      .then(
+        () => this.dialogRef.close(),
+        (error) => this.onCreateError(error.message)
+      );
   }
 
   generateSeed() {
     this.form.controls.seed.setValue(Bip39.generateMnemonic());
+  }
+
+  private onCreateError(errorMesasge: string) {
+    const config = new MatSnackBarConfig();
+    config.duration = 5000;
+    this.snackBar.open(errorMesasge, null, config);
   }
 
   private initForm() {

--- a/src/app/services/wallet.service.ts
+++ b/src/app/services/wallet.service.ts
@@ -71,7 +71,7 @@ export class WalletService {
 
       this.all.first().subscribe((wallets: Wallet[]) => {
         if (wallets.some((w: Wallet) => w.addresses[0].address === wallet.addresses[0].address)) {
-          throw new Error('trying to add an existing wallet!');
+          throw new Error('A wallet already exists with this seed');
         }
 
         this.addWallet(wallet);

--- a/src/app/services/wallet.service.ts
+++ b/src/app/services/wallet.service.ts
@@ -59,14 +59,25 @@ export class WalletService {
     this.loadBalances();
   }
 
-  create(label: string, seed: string) {
-    const wallet = {
-      label: label,
-      seed: seed,
-      addresses: [this.cipherProvider.generateAddress(this.ascii_to_hexa(seed))]
-    };
-    this.addWallet(wallet);
-    this.loadBalances();
+  create(label: string, seed: string): Promise<void> {
+    return new Promise<void>((resolve) => {
+      const wallet = {
+        label: label,
+        seed: seed,
+        addresses: [this.cipherProvider.generateAddress(this.ascii_to_hexa(seed))]
+      };
+
+      this.all.first().subscribe((wallets: Wallet[]) => {
+        if (wallets.some((w: Wallet) => w.addresses[0].address === wallet.addresses[0].address)) {
+          throw new Error('trying to add an existing wallet!');
+        }
+
+        this.addWallet(wallet);
+        this.loadBalances();
+      });
+
+      return resolve();
+    });
   }
 
   sendSkycoin(wallet: Wallet, address: string, amount: number) {


### PR DESCRIPTION
Fixes #172 

Changes:
- `walletService.create()`: add check if user creates a wallet with already existing seed;
- `walletService.create()` returns `promise<void>`, instead of `void` to have simple ability of error handling;
- update unit tests;
- update e2e tests;
