### PR TITLE
#192: The history page does not show the alert about the USD values

### DIFF
--- a/src/app/components/pages/history/history.component.html
+++ b/src/app/components/pages/history/history.component.html
@@ -24,7 +24,9 @@
           </div>
           <div class="-balance">
             <h4>{{ transaction.balance | number:'1.0-6' }} SKY</h4>
-            <p *ngIf="price">{{ transaction.balance * price | currency:'USD':symbol:'1.2-2' }}</p>
+            <p *ngIf="price" [matTooltip]="'Calculated at the current rate'">
+             {{ transaction.balance * price | currency:'USD':'symbol':'1.2-2' }}<span>*</span>
+            </p>
           </div>
         </div>
       </ng-container>


### PR DESCRIPTION
Fixes #192 

Changes:
- The history page shows the 'Calculated at the current rate' alert about the USD values
