### PR TITLE
#188: Encode the transaction before displaying the preview

### DIFF
--- a/src/app/app.datatypes.ts
+++ b/src/app/app.datatypes.ts
@@ -38,6 +38,7 @@ export class NormalTransaction extends Transaction {
 export class PreviewTransaction extends Transaction {
   from: string;
   to: string;
+  row: string;
 }
 
 export interface Output {

--- a/src/app/app.datatypes.ts
+++ b/src/app/app.datatypes.ts
@@ -38,7 +38,7 @@ export class NormalTransaction extends Transaction {
 export class PreviewTransaction extends Transaction {
   from: string;
   to: string;
-  row: string;
+  encoded: string;
 }
 
 export interface Output {

--- a/src/app/components/pages/send-skycoin/send-verify/send-verify.component.spec.ts
+++ b/src/app/components/pages/send-skycoin/send-verify/send-verify.component.spec.ts
@@ -27,7 +27,7 @@ describe('SendVerifyComponent', () => {
   beforeEach(() => {
     fixture = TestBed.createComponent(SendVerifyComponent);
     component = fixture.componentInstance;
-    component.transaction = { inputs: [], outputs: [], from: '', to: '', row: '' };
+    component.transaction = { inputs: [], outputs: [], from: '', to: '', encoded: '' };
     fixture.detectChanges();
   });
 

--- a/src/app/components/pages/send-skycoin/send-verify/send-verify.component.spec.ts
+++ b/src/app/components/pages/send-skycoin/send-verify/send-verify.component.spec.ts
@@ -27,7 +27,7 @@ describe('SendVerifyComponent', () => {
   beforeEach(() => {
     fixture = TestBed.createComponent(SendVerifyComponent);
     component = fixture.componentInstance;
-    component.transaction = { inputs: [], outputs: [], from: '', to: '' };
+    component.transaction = { inputs: [], outputs: [], from: '', to: '', row: '' };
     fixture.detectChanges();
   });
 

--- a/src/app/components/pages/send-skycoin/send-verify/send-verify.component.ts
+++ b/src/app/components/pages/send-skycoin/send-verify/send-verify.component.ts
@@ -27,7 +27,7 @@ export class SendVerifyComponent {
     this.sendButton.setLoading();
     this.backButton.setDisabled();
 
-    this.walletService.injectTransaction(this.transaction.inputs, this.transaction.outputs)
+    this.walletService.injectTransaction(this.transaction.row)
       .subscribe(
         () => this.onSuccess(),
         (error) => this.onError(error)

--- a/src/app/components/pages/send-skycoin/send-verify/send-verify.component.ts
+++ b/src/app/components/pages/send-skycoin/send-verify/send-verify.component.ts
@@ -27,7 +27,7 @@ export class SendVerifyComponent {
     this.sendButton.setLoading();
     this.backButton.setDisabled();
 
-    this.walletService.injectTransaction(this.transaction.row)
+    this.walletService.injectTransaction(this.transaction.encoded)
       .subscribe(
         () => this.onSuccess(),
         (error) => this.onError(error)

--- a/src/app/services/wallet.service.ts
+++ b/src/app/services/wallet.service.ts
@@ -66,7 +66,7 @@ export class WalletService {
       const wallet = {
         label: label,
         seed: seed,
-        addresses: [this.cipherProvider.generateAddress(this.ascii_to_hexa(seed))]
+        addresses: [this.cipherProvider.generateAddress(this.convertAsciiToHexa(seed))]
       };
 
       this.all.first().subscribe((wallets: Wallet[]) => {
@@ -187,17 +187,13 @@ export class WalletService {
           inputs: txInputs,
           outputs: txOutputs,
           hoursSent: hoursToSend,
-          hoursBurned: totalHours - calculatedHours
+          hoursBurned: totalHours - calculatedHours,
+          row: this.generateRawTransaction(txInputs, txOutputs)
         });
     });
   }
 
-  injectTransaction(txInputs: TransactionInput[], txOutputs: TransactionOutput[]): Observable<string> {
-    txOutputs.forEach(output => {
-      output.coins = parseInt((output.coins * this.coinsMultiplier) + '', 10);
-    });
-
-    const rawTransaction = this.cipherProvider.prepareTransaction(txInputs, txOutputs);
+  injectTransaction(rawTransaction: string): Observable<string> {
     return this.apiService.postTransaction(rawTransaction);
   }
 
@@ -216,7 +212,7 @@ export class WalletService {
     seed = this.getCleanSeed(seed);
 
     return new Promise<void>((resolve) => {
-      let currentSeed = this.ascii_to_hexa(seed);
+      let currentSeed = this.convertAsciiToHexa(seed);
       wallet.addresses.forEach(address => {
         const fullAddress = this.cipherProvider.generateAddress(currentSeed);
         if (fullAddress.address !== address.address) {
@@ -340,6 +336,17 @@ export class WalletService {
     });
   }
 
+  private generateRawTransaction(txInputs: TransactionInput[], txOutputs: TransactionOutput[]) {
+    const convertedOutputs: TransactionOutput[] = txOutputs.map(output => {
+      return {
+        ...output,
+        coins: parseInt((output.coins * this.coinsMultiplier) + '', 10)
+      };
+    });
+
+    return this.cipherProvider.prepareTransaction(txInputs, convertedOutputs);
+  }
+
   private calculateTotalBalance(wallets: Wallet[]) {
     const totalBalance: TotalBalance = {
       coins: wallets.map(wallet => wallet.balance >= 0 ? wallet.balance : 0).reduce((a , b) => a + b, 0),
@@ -388,7 +395,7 @@ export class WalletService {
     }).join(','));
   }
 
-  private ascii_to_hexa(str): string {
+  private convertAsciiToHexa(str): string {
     const arr1: string[] = [];
     for (let n = 0, l = str.length; n < l; n ++) {
       const hex = Number(str.charCodeAt(n)).toString(16);

--- a/src/app/services/wallet.service.ts
+++ b/src/app/services/wallet.service.ts
@@ -188,7 +188,7 @@ export class WalletService {
           outputs: txOutputs,
           hoursSent: hoursToSend,
           hoursBurned: totalHours - calculatedHours,
-          row: this.generateRawTransaction(txInputs, txOutputs)
+          encoded: this.generateRawTransaction(txInputs, txOutputs)
         });
     });
   }

--- a/src/app/services/wallet.service.ts
+++ b/src/app/services/wallet.service.ts
@@ -193,8 +193,8 @@ export class WalletService {
     });
   }
 
-  injectTransaction(rawTransaction: string): Observable<string> {
-    return this.apiService.postTransaction(rawTransaction);
+  injectTransaction(encodedTransaction: string): Observable<string> {
+    return this.apiService.postTransaction(encodedTransaction);
   }
 
   updateWallet(wallet: Wallet) {


### PR DESCRIPTION
Fixes #188 

Changes:
- rename method `ascii_to_hexa` to `convertAsciiToHexa` to be consistent in naming;
- fix the bug from the issue #190 (multiplied coins);
- move encoding of transaction by cipher provider from send-verify page to send-form page.
