### PR TITLE
#212: The QR buttons on the history page are not clickable

### DIFF
--- a/src/app/components/pages/history/history.component.html
+++ b/src/app/components/pages/history/history.component.html
@@ -25,7 +25,7 @@
               <span class="-pending">{{ 'history.pending' | translate }}</span>
             </h4>
             <div class="-detail" *ngFor="let address of transaction.addresses">
-              <img src="../../../../assets/img/qr-code-black.png">
+              <img src="../../../../assets/img/qr-code-black.png" (click)="showQr($event, address)">
               <p>{{ address }}</p>
             </div>
           </div>

--- a/src/app/components/pages/history/history.component.ts
+++ b/src/app/components/pages/history/history.component.ts
@@ -5,6 +5,7 @@ import { Subscription } from 'rxjs/Subscription';
 import { PriceService } from '../../../services/price.service';
 import { WalletService } from '../../../services/wallet.service';
 import { TransactionDetailComponent } from './transaction-detail/transaction-detail.component';
+import { QrCodeComponent } from '../../layout/qr-code/qr-code.component';
 
 @Component({
   selector: 'app-history',
@@ -35,5 +36,13 @@ export class HistoryComponent implements OnInit {
     config.width = '750px';
     config.data = transaction;
     this.dialog.open(TransactionDetailComponent, config).afterClosed().subscribe();
+  }
+
+  showQr(event, address) {
+    event.stopPropagation();
+
+    const config = new MatDialogConfig();
+    config.data = address;
+    this.dialog.open(QrCodeComponent, config);
   }
 }


### PR DESCRIPTION
Fixes #212

Changes:
- added event handler on click event to show QR code.
