### PR TITLE
#165: Add tests for the transaction verification screen

### DIFF
--- a/src/app/services/wallet.service.spec.ts
+++ b/src/app/services/wallet.service.spec.ts
@@ -368,6 +368,7 @@ describe('WalletService', () => {
       ];
 
       spyApiService.getOutputs.and.returnValue(Observable.of(outputs));
+      spyCipherProvider.prepareTransaction.and.returnValue('preparedTransaction');
 
       walletService.createTransaction(wallet, address, amount)
         .subscribe((result: any) => {
@@ -375,7 +376,8 @@ describe('WalletService', () => {
             inputs: expectedTxInputs,
             outputs: expectedTxOutputs,
             hoursSent: 17,
-            hoursBurned: 35
+            hoursBurned: 35,
+            encoded: 'preparedTransaction'
           });
         });
     }));
@@ -407,14 +409,17 @@ describe('WalletService', () => {
       ];
 
       spyApiService.getOutputs.and.returnValue(Observable.of(outputs));
+      spyCipherProvider.prepareTransaction.and.returnValue('preparedTransaction');
 
       walletService.createTransaction(wallet, address, amount)
         .subscribe((result: any) => {
+          console.info(result);
           expect(result).toEqual({
             inputs: expectedTxInputs,
             outputs: expectedTxOutputs,
             hoursSent: 5,
-            hoursBurned: 5
+            hoursBurned: 5,
+            encoded: 'preparedTransaction'
           });
         });
     }));

--- a/src/app/services/wallet.service.spec.ts
+++ b/src/app/services/wallet.service.spec.ts
@@ -413,7 +413,6 @@ describe('WalletService', () => {
 
       walletService.createTransaction(wallet, address, amount)
         .subscribe((result: any) => {
-          console.info(result);
           expect(result).toEqual({
             inputs: expectedTxInputs,
             outputs: expectedTxOutputs,


### PR DESCRIPTION
Fixes #165

Changes:
- added unit-tests for `walletService.createTransaction()`
