### PR TITLE
Fix balance update problems

### DIFF
--- a/src/app/services/wallet.service.ts
+++ b/src/app/services/wallet.service.ts
@@ -321,7 +321,7 @@ export class WalletService {
     this.addresses.first().subscribe((addresses: Address[]) => {
       this.retrieveAddressesBalance(addresses).subscribe(
         (balance: Balance) => { this.wallets.first().subscribe(wallets => this.calculateBalance(wallets, balance)); },
-        () => {this.updatingBalance = false; this.resetBalancesUpdateTime(true);},
+        () => { this.updatingBalance = false; this.resetBalancesUpdateTime(true); },
         () => this.updatingBalance = false
       );
     });


### PR DESCRIPTION
Fixes #225

Changes:
- If there is an error when connecting to the server, the balance will be updated again after 20 seconds (the timer is restarted as if there were pending transactions).
- The number of minutes that has passed since the last balance update is rounded down.