### PR TITLE
#236: Close the MatSnackBar when navigatin from the send coins form

### DIFF
--- a/src/app/components/pages/send-skycoin/send-form/send-form.component.spec.ts
+++ b/src/app/components/pages/send-skycoin/send-form/send-form.component.spec.ts
@@ -21,6 +21,11 @@ class MockWalletService {
   }
 }
 
+class MockMatSnackBar {
+  dismiss() {
+  }
+}
+
 describe('SendFormComponent', () => {
   let component: SendFormComponent;
   let fixture: ComponentFixture<SendFormComponent>;
@@ -33,7 +38,7 @@ describe('SendFormComponent', () => {
       providers: [
         FormBuilder,
         { provide: WalletService, useClass: MockWalletService },
-        { provide: MatDialog, useValue: {} }
+        { provide: MatDialog, useClass: MockMatSnackBar }
       ]
     }).compileComponents();
   }));

--- a/src/app/components/pages/send-skycoin/send-form/send-form.component.ts
+++ b/src/app/components/pages/send-skycoin/send-form/send-form.component.ts
@@ -42,6 +42,7 @@ export class SendFormComponent implements OnInit, OnDestroy {
 
   ngOnDestroy() {
     this.subscription.unsubscribe();
+    this.snackbar.dismiss();
   }
 
   onVerify() {


### PR DESCRIPTION
Fixes #236

Changes:
- close `MatSnackBar` when user navigates from send coins form to another page.
