### PR TITLE
#238: Hide the text with the minutes since the last update, if the wallet is still loading

### DIFF
--- a/src/app/components/layout/header/top-bar/top-bar.component.html
+++ b/src/app/components/layout/header/top-bar/top-bar.component.html
@@ -1,5 +1,5 @@
 <div class="buttons-left">
-  <span class="last-updated-time">
+  <span class="last-updated-time" *ngIf="isBalanceObtained">
     {{ 'header.updated1' | translate }} {{ timeSinceLastUpdateBalances === 0 ? ('top-bar.less-than' | translate ) : timeSinceLastUpdateBalances }} {{ 'header.updated2' | translate }}
     <i *ngIf="!this.isBalanceUpdated"
        class="material-icons blinking-warning-icon"

--- a/src/app/components/layout/header/top-bar/top-bar.component.ts
+++ b/src/app/components/layout/header/top-bar/top-bar.component.ts
@@ -13,6 +13,7 @@ export class TopBarComponent implements OnInit, OnDestroy {
   @Input() headline: string;
 
   timeSinceLastUpdateBalances = 0;
+  isBalanceObtained = false;
   isBalanceUpdated: boolean;
   private updateBalancesSubscription: Subscription;
 
@@ -22,6 +23,10 @@ export class TopBarComponent implements OnInit, OnDestroy {
   ngOnInit() {
     this.walletService.totalBalance
       .subscribe((balance: TotalBalance) => {
+        if (balance && !this.isBalanceObtained) {
+          this.isBalanceObtained = true;
+        }
+
         this.isBalanceUpdated = !!balance;
       });
 


### PR DESCRIPTION
Fixes #238 

Changes:
- Disabled "how many minutes have passed since the last time the balance was updated " message while the wallet has not yet obtained the balance for the first time and shows "Loading" in the header.