### PR TITLE
Base for web workers

### DIFF
--- a/src/app/utils/web-workers-helper.ts
+++ b/src/app/utils/web-workers-helper.ts
@@ -1,0 +1,27 @@
+import { Observable } from 'rxjs/Observable';
+import { Subject } from 'rxjs/Subject';
+import { isString } from 'util';
+
+export class WebWorkersHelper {
+
+  private static readonly errPrefix = 'Error:';
+
+  static ExcecuteWorker(fileName: string, data: any): Observable<any> {
+
+    return Observable.create((obs: Subject<any>) => {
+      const worker = new Worker(fileName);
+      worker.addEventListener('message', (e: MessageEvent) => {
+        if (isString(e.data) && (e.data as string).startsWith(WebWorkersHelper.errPrefix)) {
+          // Return the error message without the content of errPrefix.
+          obs.error(new Error((e.data as string).substr(WebWorkersHelper.errPrefix.length, (e.data as string).length - WebWorkersHelper.errPrefix.length)));
+        } else {
+          obs.next(e.data);
+        }
+        obs.complete();
+      });
+
+      worker.postMessage(data);
+    });
+
+  }
+}

--- a/src/assets/scripts/workers/generate-addresses.worker.js
+++ b/src/assets/scripts/workers/generate-addresses.worker.js
@@ -1,0 +1,11 @@
+importScripts('../main.js');
+
+onmessage = function(e) {
+  try {
+    postMessage(Cipher.GenerateAddresses(e.data));
+  } catch(err) {
+    // The error message must be prefixed with "Error:" to be recognized as an error
+    // message and not as a valid response. The prefix is defined in WebWorkersHelper.errPrefix.
+    postMessage("Error:" + err.message);
+  }
+}


### PR DESCRIPTION
Fixes #263 

Changes:
- Adds `WebWorkersHelper` to help run the web workers.
- Adds `generate-addresses.worker.js` as an example web woker.

This PR aims to define an standard procedure for the creation of web workers in this repository.

This PR includes `generate-addresses.worker.js` as an example of how to create a web worker. It is simply a JavaScript file that follows the standard format for creating web workers. The example simply creates an address from a seed, similarly (though more simply) to how `CipherProvider.generateAddress` does it. The example shows how to access the `Cipher` object from a web worker.

The web worker is not coded in TypeScript because that would imply making relatively complicated changes to Webpack, which is too much trouble considering the simplicity of the procedures that should be implemented.

It is important to note that the errors are handled within the web worker, in a try-catch block. In case of error, it is necessary to return the error message with the prefix "Error:", to be able to identify that there was an error and that the text in the response is the explanation of that error. This is because if the error is not captured in the web worker, but in an event, the browser may add a prefix to the error message. As error messages are displayed to the user, that behavior is not desirable.

Apart from the example web worker, this pr includes the `WebWorkersHelper` class, which must be used to run the web workers. When calling `WebWorkersHelper.ExcecuteWorker` with the path of the web worker file and the object that the web worker should receive as a parameter, it takes care of executing the web worker, processing the error messages and return the response through an observable. In this way it is possible to run the web workers without having to make big changes to the current style of the code.

As an example, it is possible to get an address with this code:

```
WebWorkersHelper.ExcecuteWorker("/assets/scripts/workers/generate-addresses.worker.js", "12345").subscribe(
  (response: string) => alert(JSON.stringify(response)),
  (e: Error) => alert(e.message)
);
```

The first parameter sent to `WebWorkersHelper.ExcecuteWorker` is the path of the file with the procedure to be executed and the second one is the seed. Note that the seed was not processed with `convertAsciiToHexa`, as is normally done in order to create an address. Due to this, if the "12345" seed is changed to a text like "seed", an error occurs and the message with the explanation of what happened is shown in an alert.