### PR TITLE
#260: Show the loading animation until geting the balance for the first time

### DIFF
--- a/src/app/components/layout/header/header.component.ts
+++ b/src/app/components/layout/header/header.component.ts
@@ -86,8 +86,8 @@ export class HeaderComponent implements OnInit, OnDestroy {
       return;
     }
 
-    this.querying = false;
     this.isBlockchainLoading = response.highest !== response.current;
+    this.querying = !this.isBlockchainLoading && !this.isBalanceLoaded;
 
     if (this.isBlockchainLoading) {
       this.highest = response.highest;


### PR DESCRIPTION
Fixes #206

Changes:
- "querying" loading animation has been added when balance has not yet been obtained.