### PR TITLE
Make Travis work in the develop branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ node_js:
 branches:
   only:
     - master
+    - develop
 
 services:
   - docker


### PR DESCRIPTION
Fixes #272 

Changes:
- Add "develop" to the list of branches taken into account by Travis.
