### PR TITLE
#276: Should be able to create a wallet with a one letter name in the wizard

### DIFF
--- a/e2e/wallets.e2e-spec.ts
+++ b/e2e/wallets.e2e-spec.ts
@@ -28,12 +28,12 @@ describe('Wallets', () => {
     expect<any>(page.showAddWallet()).toEqual(true);
   });
 
-  it('should validate create wallet, seed mismatch', () => {
-    expect<any>(page.createWalletCheckValidationSeed()).toEqual(false);
-  });
-
   it('should validate create wallet, empty label', () => {
     expect<any>(page.createWalletCheckValidationLabel()).toEqual(false);
+  });
+
+  it('should validate create wallet, seed mismatch', () => {
+    expect<any>(page.createWalletCheckValidationSeed()).toEqual(false);
   });
 
   it('should not create wallet with already used seed', () => {
@@ -48,16 +48,16 @@ describe('Wallets', () => {
     expect<any>(page.showLoadWallet()).toEqual(true);
   });
 
-  it('should validate load wallet, seed', () => {
-    expect<any>(page.loadWalletCheckValidationSeed()).toEqual(false);
-  });
-
   it('should validate load wallet, empty label', () => {
     expect<any>(page.loadWalletCheckValidationLabel()).toEqual(false);
   });
 
   it('should not load wallet with already used seed', () => {
     expect<any>(page.loadExistingWallet()).toEqual(false);
+  });
+
+  it('should validate load wallet, seed', () => {
+    expect<any>(page.loadWalletCheckValidationSeed()).toEqual(false);
   });
 
   it('should load wallet', () => {

--- a/e2e/wallets.po.ts
+++ b/e2e/wallets.po.ts
@@ -45,15 +45,21 @@ export class WalletsPage {
   }
 
   loadWalletCheckValidationSeed() {
+    const cancelAdd = element(by.buttonText('Cancel'));
+    const btnAdd = element(by.buttonText('Load Wallet'));
     const label = element(by.css('[formcontrolname="label"]'));
     const seed = element(by.css('[formcontrolname="seed"]'));
     const btnLoad = element(by.buttonText('Load'));
 
-    return label.clear().then(() => {
-      return label.sendKeys('Test wallet').then(() => {
-        return seed.clear().then(() => {
-          return seed.sendKeys(' ').then(() => {
-            return btnLoad.isEnabled();
+    return cancelAdd.click().then(() => {
+      return btnAdd.click().then(() => {
+        return label.clear().then(() => {
+          return label.sendKeys('Test wallet').then(() => {
+            return seed.clear().then(() => {
+              return seed.sendKeys('').then(() => {
+                return btnLoad.isEnabled();
+              });
+            });
           });
         });
       });
@@ -67,7 +73,7 @@ export class WalletsPage {
     const btnCreate = element(by.buttonText('Create'));
 
     return label.clear().then(() => {
-      return label.sendKeys(' ').then(() => {
+      return label.sendKeys('').then(() => {
         return seed.clear().then(() => {
           return seed.sendKeys('skycoin-web-e2e-test-seed').then(() => {
             return confirm.clear().then(() => {
@@ -87,7 +93,7 @@ export class WalletsPage {
     const btnLoad = element(by.buttonText('Load'));
 
     return label.clear().then(() => {
-      return label.sendKeys(' ').then(() => {
+      return label.sendKeys('').then(() => {
         return seed.clear().then(() => {
           return seed.sendKeys('skycoin-web-e2e-test-seed').then(() => {
             return btnLoad.isEnabled();

--- a/src/app/components/pages/onboarding/onboarding-create-wallet/onboarding-create-wallet.component.ts
+++ b/src/app/components/pages/onboarding/onboarding-create-wallet/onboarding-create-wallet.component.ts
@@ -47,23 +47,14 @@ export class OnboardingCreateWalletComponent implements OnInit {
 
   initForm() {
     this.form = this.formBuilder.group({
-        label: new FormControl('', Validators.compose([
-          Validators.required, Validators.minLength(2),
-        ])),
-        seed: new FormControl('', Validators.compose([
-          Validators.required, Validators.minLength(2),
-        ])),
-        confirm_seed: new FormControl('',
-          this.showNewForm ?
-            Validators.compose([
-              Validators.required,
-              Validators.minLength(2),
-            ])
-            : Validators.compose([]),
-        ),
+        label: new FormControl('', [ Validators.required ]),
+        seed: new FormControl('', [ Validators.required ]),
+        confirm_seed: new FormControl()
       },
-      this.showNewForm ? { validator: this.seedMatchValidator.bind(this) } : {},
-      );
+      {
+        validator: this.showNewForm ? this.seedMatchValidator.bind(this) : null
+      }
+    );
 
     if (this.showNewForm) {
       this.generateSeed(128);
@@ -110,8 +101,7 @@ export class OnboardingCreateWalletComponent implements OnInit {
   }
 
   private seedMatchValidator(g: FormGroup) {
-      return g.get('seed').value === g.get('confirm_seed').value
-        ? null : { mismatch: true };
+    return g.get('seed').value === g.get('confirm_seed').value ? null : { NotEqual: true };
   }
 
   private onCreateError(errorMesasge: string) {

--- a/src/app/components/pages/wallets/create-wallet/create-wallet.component.ts
+++ b/src/app/components/pages/wallets/create-wallet/create-wallet.component.ts
@@ -51,22 +51,13 @@ export class CreateWalletComponent implements OnInit {
 
   private initForm() {
     this.form = this.formBuilder.group({
-        label: new FormControl('', Validators.compose([
-          Validators.required,
-          Validators.minLength(2)
-        ])),
-        seed: new FormControl('', Validators.compose([
-          Validators.required,
-          Validators.minLength(2)
-        ])),
-        confirm_seed: new FormControl('',
-            Validators.compose([
-              this.data.create ? Validators.required : null,
-              this.data.create ? Validators.minLength(2) : null,
-            ]),
-        ),
+        label: new FormControl('', [ Validators.required ]),
+        seed: new FormControl('', [ Validators.required ]),
+        confirm_seed: new FormControl(),
       },
-      { validator: this.data.create ? this.seedMatchValidator.bind(this) : null }
+      {
+        validator: this.data.create ? this.seedMatchValidator.bind(this) : null,
+      }
     );
 
     if (this.data.create) {
@@ -75,7 +66,6 @@ export class CreateWalletComponent implements OnInit {
   }
 
   private seedMatchValidator(formGroup: FormGroup) {
-    return formGroup.get('seed').value === formGroup.get('confirm_seed').value
-      ? null : { mismatch: true };
+    return formGroup.get('seed').value === formGroup.get('confirm_seed').value ? null : { NotEqual: true };
   }
 }


### PR DESCRIPTION
Fixes #276 

Changes:
- Added ability to create a wallet with a one letter name in the wizard for "onboarding-create-wallet.component.ts" and "create-wallet.component.ts" components
- Fixed e2e tests

