### PR TITLE
#292: Show the loading spinner in the wizard

### DIFF
--- a/src/app/components/layout/button/button.component.html
+++ b/src/app/components/layout/button/button.component.html
@@ -14,5 +14,5 @@
   <ng-content></ng-content>
   <mat-icon *ngIf="state === 1">done</mat-icon>
   <mat-icon *ngIf="state === 2">error</mat-icon>
-  <mat-spinner *ngIf="state === 0" class="in-button"></mat-spinner>
+  <mat-spinner *ngIf="state === 0" [color]="spinnerStyle" class="in-button"></mat-spinner>
 </button>

--- a/src/app/components/layout/button/button.component.ts
+++ b/src/app/components/layout/button/button.component.ts
@@ -10,6 +10,7 @@ import { MatTooltip } from '@angular/material';
 export class ButtonComponent {
   @Input() disabled: boolean;
   @Input() emit = false;
+  @Input() spinnerStyle = 'primary';
   @Output() action = new EventEmitter();
   @ViewChild('tooltip') tooltip: MatTooltip;
 

--- a/src/app/components/pages/onboarding/onboarding-create-wallet/onboarding-create-wallet.component.html
+++ b/src/app/components/pages/onboarding/onboarding-create-wallet/onboarding-create-wallet.component.html
@@ -47,12 +47,17 @@
     </div>
   </div>
   <div class="row -buttons-footer">
-    <app-button class="dark -button-min-margin" [disabled]="!form.valid"
+    <app-button #create
+                class="dark -button-min-margin"
+                [disabled]="!form.valid"
+                [spinnerStyle]="'accent'"
                 (action)="showNewForm ? showSafe() : loadWallet()">
       {{ 'wallet.new.create-button' | translate }}
     </app-button>
     <app-button *ngIf="haveWallets"
-      class="ghost -button-min-margin" (action)="skip()">
+                [disabled]="isWalletCreating"
+                class="ghost -button-min-margin"
+                (action)="skip()">
       {{ 'wallet.new.skip-button' | translate }}
     </app-button>
   </div>

--- a/src/app/components/pages/onboarding/onboarding-create-wallet/onboarding-create-wallet.component.spec.ts
+++ b/src/app/components/pages/onboarding/onboarding-create-wallet/onboarding-create-wallet.component.spec.ts
@@ -7,10 +7,6 @@ import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { BrowserDynamicTestingModule } from '@angular/platform-browser-dynamic/testing';
 import { Observable } from 'rxjs/Observable';
 
-
-
-
-
 import { OnboardingCreateWalletComponent } from './onboarding-create-wallet.component';
 import { WalletService } from '../../../../services/wallet.service';
 import { Wallet } from '../../../../app.datatypes';

--- a/src/app/components/pages/onboarding/onboarding-create-wallet/onboarding-create-wallet.component.ts
+++ b/src/app/components/pages/onboarding/onboarding-create-wallet/onboarding-create-wallet.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, OnInit, ViewChild } from '@angular/core';
 import { FormBuilder, FormControl, FormGroup, Validators } from '@angular/forms';
 import { MatDialog, MatDialogConfig } from '@angular/material/dialog';
 import { Router } from '@angular/router';
@@ -20,6 +20,8 @@ export class OnboardingCreateWalletComponent implements OnInit {
   form: FormGroup;
   doubleButtonActive = DoubleButtonActive.LeftButton;
   haveWallets = false;
+  isWalletCreating = false;
+  @ViewChild('create') createButton;
 
   constructor(
     private dialog: MatDialog,
@@ -93,10 +95,20 @@ export class OnboardingCreateWalletComponent implements OnInit {
   }
 
   private createWallet() {
+    this.createButton.setLoading();
+    this.isWalletCreating = true;
+
     this.walletService.create(this.form.value.label, this.form.value.seed)
       .subscribe(
-        () => this.skip(),
-        (error) => this.onCreateError(error.message)
+        () => {
+            this.createButton.setSuccess();
+            this.skip();
+        },
+        (error) => {
+          this.onCreateError(error.message);
+          this.createButton.setError(error.message);
+          this.isWalletCreating = false;
+        }
       );
   }
 


### PR DESCRIPTION
Fixes #292 

Changes:
- Spinner in loading spinner is displayed on the "Create" button when creating a wallet in the wizard
- "Skip" button is disabled while creating a wallet
- "spinnerStyle" input property has been added to the "button.component" in order to use alternative spinner color (by default it was black spinner on black "create" button)
- minor refactoring of the involved components