### PR TITLE
#293: Incorrect alignments on the create wallet page

### DIFF
--- a/src/app/components/pages/wallets/create-wallet/create-wallet.component.html
+++ b/src/app/components/pages/wallets/create-wallet/create-wallet.component.html
@@ -4,7 +4,7 @@
       <label for="label">{{ 'wallet.new.name-label' | translate}}</label>
       <input formControlName="label" id="label">
     </div>
-    <div class="form-field -valid-seed-container" [ngClass]="{'-expand':form.get('seed').valid}">
+    <div class="form-field -valid-seed-container" [ngClass]="{'-expand':form.get('seed').valid && !data.create}">
       <label for="seed">
         <span>{{ 'wallet.new.seed-label' | translate }}</span>
         <span class="generators" *ngIf="data.create">


### PR DESCRIPTION
Fixes #293 

Changes:
- "Seed" text area has been aligned with "Name" and "Confirm seed" fields on the "Create wallet" page
