### PR TITLE
#334: Get the names of the coins from CoinService

### DIFF
--- a/src/app/components/layout/header/header.component.html
+++ b/src/app/components/layout/header/header.component.html
@@ -5,15 +5,15 @@
     <app-top-bar [headline]="headline"></app-top-bar>
     <div class="balance-container">
       <div class="balance">
-        <p *ngIf="!highest && loading" class="loading-header">{{ 'header.loading' | translate}}</p>
+        <p *ngIf="!highest && loading" class="loading-header">{{ 'header.loading' | translate }}</p>
         <p *ngIf="highest && loading" class="coins"><span>{{ percentage | percent:'1.2-2' }}</span></p>
-        <p *ngIf="!loading" class="coins"><span>{{ coins | number:'1.0-6' }}</span> {{ 'header.coin-id' | translate}}</p>
+        <p *ngIf="!loading" class="coins"><span>{{ coins | number:'1.0-6' }}</span> {{ currentCoin.coinSymbol }}</p>
         <p *ngIf="!loading" class="dollars">{{ balance }}</p>
       </div>
     </div>
     <div class="hour-balance">
-      <p *ngIf="loading">{{ 'header.syncing-blocks' | translate}} {{ current && highest ?  '(' + current + '/'  + highest + ')' : '..' }}</p>
-      <p *ngIf="!loading">{{ hours }} {{ 'common.coin-hours' | translate}}</p>
+      <p *ngIf="loading">{{ 'header.syncing-blocks' | translate }} {{ current && highest ?  '(' + current + '/'  + highest + ')' : '..' }}</p>
+      <p *ngIf="!loading">{{ hours }} {{ currentCoin.hoursName }}</p>
     </div>
   </div>
   <app-nav-bar></app-nav-bar>
@@ -26,15 +26,15 @@
   </mat-progress-bar>
   <mat-toolbar class="notification-bar" *ngIf="connectionError != null">
     <div *ngIf="connectionError === connectionErrorsList.NO_ACTIVE_CONNECTIONS">
-      {{ 'header.errors.no-connections' | translate}}
+      {{ 'header.errors.no-connections' | translate }}
     </div>
     <div *ngIf="connectionError === connectionErrorsList.UNAVAILABLE_BACKEND">
-      {{ 'header.errors.no-backend1' | translate}}
-      <a href="https://web.telegram.org/#/im?p=@skycoinsupport">{{ 'header.errors.no-backend2' | translate}}</a>
+      {{ 'header.errors.no-backend1' | translate }}
+      <a href="https://web.telegram.org/#/im?p=@skycoinsupport">{{ 'header.errors.no-backend2' | translate }}</a>
       {{ 'header.errors.no-backend3' | translate }}
     </div>
   </mat-toolbar>
   <mat-toolbar class="notification-bar" *ngIf="hasPendingTxs">
-    <div>{{ 'header.pending-txs1' | translate}} <a routerLink="/settings/pending-transactions">{{ 'header.pending-txs2' | translate}}</a> {{ 'header.pending-txs3' | translate}}</div>
+    <div>{{ 'header.pending-txs1' | translate }} <a routerLink="/settings/pending-transactions">{{ 'header.pending-txs2' | translate }}</a> {{ 'header.pending-txs3' | translate }}</div>
   </mat-toolbar>
 </div>

--- a/src/app/components/layout/header/header.component.spec.ts
+++ b/src/app/components/layout/header/header.component.spec.ts
@@ -10,6 +10,8 @@ import { PriceService } from '../../../services/price.service';
 import { WalletService } from '../../../services/wallet.service';
 import { BlockchainService } from '../../../services/blockchain.service';
 import { TotalBalance } from '../../../app.datatypes';
+import { CoinService } from '../../../services/coin.service';
+import { BaseCoin } from '../../../coins/basecoin';
 
 class MockPriceService {
   price: Subject<number> = new BehaviorSubject<number>(null);
@@ -27,6 +29,10 @@ class MockBlockchainService {
   get progress() {
     return Observable.of();
   }
+}
+
+class MockCoinService {
+  currentCoin = new BehaviorSubject<BaseCoin>(null);
 }
 
 @Pipe({name: 'translate'})
@@ -47,7 +53,8 @@ describe('HeaderComponent', () => {
       providers: [
         { provide: PriceService, useClass: MockPriceService },
         { provide: WalletService, useClass: MockWalletService },
-        { provide: BlockchainService, useClass: MockBlockchainService }
+        { provide: BlockchainService, useClass: MockBlockchainService },
+        { provide: CoinService, useClass: MockCoinService }
       ]
     }).compileComponents();
   }));

--- a/src/app/components/layout/header/header.component.ts
+++ b/src/app/components/layout/header/header.component.ts
@@ -6,6 +6,8 @@ import { WalletService } from '../../../services/wallet.service';
 import { BlockchainService } from '../../../services/blockchain.service';
 import { ConnectionError } from '../../../enums/connection-error.enum';
 import { TotalBalance } from '../../../app.datatypes';
+import { CoinService } from '../../../services/coin.service';
+import { BaseCoin } from '../../../coins/basecoin';
 
 @Component({
   selector: 'app-header',
@@ -25,6 +27,7 @@ export class HeaderComponent implements OnInit, OnDestroy {
   querying = true;
   current: number;
   highest: number;
+  currentCoin: BaseCoin;
 
   private isBlockchainLoading = false;
   private isBalanceLoaded = false;
@@ -32,6 +35,7 @@ export class HeaderComponent implements OnInit, OnDestroy {
   private priceSubscription: Subscription;
   private walletSubscription: Subscription;
   private blockchainSubscription: Subscription;
+  private coinSubscription: Subscription;
 
   get loading() {
     return this.isBlockchainLoading || !this.balance || !this.isBalanceLoaded;
@@ -40,7 +44,8 @@ export class HeaderComponent implements OnInit, OnDestroy {
   constructor(
     private priceService: PriceService,
     private walletService: WalletService,
-    private blockchainService: BlockchainService
+    private blockchainService: BlockchainService,
+    private coinService: CoinService
   ) {}
 
   ngOnInit() {
@@ -67,12 +72,16 @@ export class HeaderComponent implements OnInit, OnDestroy {
 
     this.walletService.hasPendingTransactions
       .subscribe(hasPendingTxs => this.hasPendingTxs = hasPendingTxs);
+
+    this.coinSubscription = this.coinService.currentCoin
+      .subscribe((coin: BaseCoin) => this.currentCoin = coin);
   }
 
   ngOnDestroy() {
     this.priceSubscription.unsubscribe();
     this.walletSubscription.unsubscribe();
     this.blockchainSubscription.unsubscribe();
+    this.coinSubscription.unsubscribe();
   }
 
   private updateBlockchainProgress(response) {

--- a/src/app/components/pages/history/history.component.html
+++ b/src/app/components/pages/history/history.component.html
@@ -10,19 +10,19 @@
           </div>
           <div class="-address">
             <h4 *ngIf="transaction.balance < 0 && transaction.confirmed">
-              {{ 'history.sent' | translate }} {{ 'common.coin-id' | translate }}
+              {{ 'history.sent' | translate }} {{ currentCoin.coinSymbol }}
               <span class="-timestamp">{{ transaction.timestamp * 1000 | date:'short' }}</span>
             </h4>
             <h4 *ngIf="transaction.balance < 0 && !transaction.confirmed">
-              {{ 'history.sending' | translate }} {{ 'common.coin-id' | translate }}
+              {{ 'history.sending' | translate }} {{ currentCoin.coinSymbol }}
               <span class="-pending">{{ 'history.pending' | translate }}</span>
             </h4>
             <h4 *ngIf="transaction.balance > 0 && transaction.confirmed">
-              {{ 'history.received' | translate }}  {{ 'common.coin-id' | translate }}
+              {{ 'history.received' | translate }}  {{ currentCoin.coinSymbol }}
               <span class="-timestamp">{{ transaction.timestamp * 1000 | date:'short' }}</span>
             </h4>
             <h4 *ngIf="transaction.balance > 0 && !transaction.confirmed">
-              {{ 'history.receiving' | translate }} {{ 'common.coin-id' | translate }}
+              {{ 'history.receiving' | translate }} {{ currentCoin.coinSymbol }}
               <span class="-pending">{{ 'history.pending' | translate }}</span>
             </h4>
             <div class="-detail" *ngFor="let address of transaction.addresses">
@@ -31,7 +31,7 @@
             </div>
           </div>
           <div class="-balance">
-            <h4>{{ transaction.balance | number:'1.0-6' }} {{ 'common.coin-id' | translate }}</h4>
+            <h4>{{ transaction.balance | number:'1.0-6' }} {{ currentCoin.coinSymbol }}</h4>
             <p *ngIf="price" [matTooltip]="'history.price-tooltip' | translate">
              {{ transaction.balance * price | currency:'USD':'symbol':'1.2-2' }}<span>*</span>
             </p>

--- a/src/app/components/pages/history/history.component.spec.ts
+++ b/src/app/components/pages/history/history.component.spec.ts
@@ -7,6 +7,8 @@ import { Observable } from 'rxjs/Observable';
 import { HistoryComponent } from './history.component';
 import { WalletService } from '../../../services/wallet.service';
 import { PriceService } from '../../../services/price.service';
+import { BaseCoin } from '../../../coins/basecoin';
+import { CoinService } from '../../../services/coin.service';
 
 class MockWalletService {
   transactions(): Observable<any[]> {
@@ -16,6 +18,10 @@ class MockWalletService {
 
 class MockPriceService {
   price: BehaviorSubject<number> = new BehaviorSubject<number>(null);
+}
+
+class MockCoinService {
+  currentCoin = new BehaviorSubject<BaseCoin>(null);
 }
 
 @Pipe({name: 'translate'})
@@ -36,7 +42,8 @@ describe('HistoryComponent', () => {
       providers: [
         MatDialog,
         { provide: WalletService, useClass: MockWalletService },
-        { provide: PriceService, useClass: MockPriceService }
+        { provide: PriceService, useClass: MockPriceService },
+        { provide: CoinService, useClass: MockCoinService }
       ],
       schemas: [ NO_ERRORS_SCHEMA ]
     });

--- a/src/app/components/pages/history/history.component.ts
+++ b/src/app/components/pages/history/history.component.ts
@@ -6,6 +6,8 @@ import { PriceService } from '../../../services/price.service';
 import { WalletService } from '../../../services/wallet.service';
 import { TransactionDetailComponent } from './transaction-detail/transaction-detail.component';
 import { QrCodeComponent } from '../../layout/qr-code/qr-code.component';
+import { BaseCoin } from '../../../coins/basecoin';
+import { CoinService } from '../../../services/coin.service';
 
 @Component({
   selector: 'app-history',
@@ -14,14 +16,18 @@ import { QrCodeComponent } from '../../layout/qr-code/qr-code.component';
 })
 
 export class HistoryComponent implements OnInit, OnDestroy {
+  currentCoin: BaseCoin;
+
   public transactions: any[];
   public price: number;
   private priceSubscription: Subscription;
+  private coinSubscription: Subscription;
 
   constructor(
     private walletService: WalletService,
     private priceService: PriceService,
     private dialog: MatDialog,
+    private coinService: CoinService
   ) { }
 
   ngOnInit() {
@@ -29,10 +35,14 @@ export class HistoryComponent implements OnInit, OnDestroy {
     this.walletService.transactions().subscribe(transactions => {
       this.transactions = transactions;
     });
+
+    this.coinSubscription = this.coinService.currentCoin
+      .subscribe((coin: BaseCoin) => this.currentCoin = coin);
   }
 
   ngOnDestroy() {
     this.priceSubscription.unsubscribe();
+    this.coinSubscription.unsubscribe();
   }
 
   showTransaction(transaction: any) {

--- a/src/app/components/pages/send-skycoin/send-form/send-form.component.html
+++ b/src/app/components/pages/send-skycoin/send-form/send-form.component.html
@@ -7,7 +7,7 @@
         <option *ngFor="let wallet of wallets"
                 [disabled]="!wallet.balance || wallet.balance <= 0"
                 [ngValue]="wallet">
-          {{ wallet.label }} — {{ wallet.balance | number:'1.0-6' }} {{ 'common.coin-id' | translate }}
+          {{ wallet.label }} — {{ wallet.balance | number:'1.0-6' }} {{ currentCoin.coinSymbol }}
         </option>
       </select>
     </div>
@@ -19,7 +19,7 @@
   </div>
   <div class="form-field">
     <label for="amount">{{ 'send.amount-label' | translate }}</label>
-    <input formControlName="amount" id="amount" [placeholder]="'common.coin-id' | translate" type="number" (keydown.enter)="onVerify()">
+    <input formControlName="amount" id="amount" [placeholder]="currentCoin.coinSymbol" type="number" (keydown.enter)="onVerify()">
   </div>
 
   <div class="-buttons">

--- a/src/app/components/pages/send-skycoin/send-form/send-form.component.spec.ts
+++ b/src/app/components/pages/send-skycoin/send-form/send-form.component.spec.ts
@@ -3,10 +3,13 @@ import { MatSnackBarModule, MatDialog } from '@angular/material';
 import { NO_ERRORS_SCHEMA, PipeTransform, Pipe } from '@angular/core';
 import { FormBuilder } from '@angular/forms';
 import { Observable } from 'rxjs/Observable';
+import { BehaviorSubject } from 'rxjs/BehaviorSubject';
 
 import { SendFormComponent } from './send-form.component';
 import { WalletService } from '../../../../services/wallet.service';
 import { Wallet } from '../../../../app.datatypes';
+import { BaseCoin } from '../../../../coins/basecoin';
+import { CoinService } from '../../../../services/coin.service';
 
 @Pipe({name: 'translate'})
 class MockTranslatePipe implements PipeTransform {
@@ -19,6 +22,17 @@ class MockWalletService {
   get all(): Observable<Wallet[]> {
     return Observable.of([]);
   }
+}
+
+class MockCoinService {
+  currentCoin = new BehaviorSubject<BaseCoin>({
+    id: 1,
+    nodeUrl: 'nodeUrl',
+    nodeVersion: 'v1',
+    coinName: 'test coin',
+    coinSymbol: 'test',
+    hoursName: 'test'
+  });
 }
 
 class MockMatSnackBar {
@@ -38,7 +52,8 @@ describe('SendFormComponent', () => {
       providers: [
         FormBuilder,
         { provide: WalletService, useClass: MockWalletService },
-        { provide: MatDialog, useClass: MockMatSnackBar }
+        { provide: MatDialog, useClass: MockMatSnackBar },
+        { provide: CoinService, useClass: MockCoinService }
       ]
     }).compileComponents();
   }));

--- a/src/app/components/pages/send-skycoin/send-form/send-form.component.spec.ts
+++ b/src/app/components/pages/send-skycoin/send-form/send-form.component.spec.ts
@@ -31,7 +31,8 @@ class MockCoinService {
     nodeVersion: 'v1',
     coinName: 'test coin',
     coinSymbol: 'test',
-    hoursName: 'test'
+    hoursName: 'test',
+    cmcTickerId: 1
   });
 }
 

--- a/src/app/components/pages/send-skycoin/send-form/send-form.component.ts
+++ b/src/app/components/pages/send-skycoin/send-form/send-form.component.ts
@@ -9,6 +9,8 @@ import { WalletService } from '../../../../services/wallet.service';
 import { ButtonComponent } from '../../../layout/button/button.component';
 import { Wallet } from '../../../../app.datatypes';
 import { openUnlockWalletModal } from '../../../../utils/index';
+import { BaseCoin } from '../../../../coins/basecoin';
+import { CoinService } from '../../../../services/coin.service';
 
 @Component({
   selector: 'app-send-form',
@@ -23,14 +25,17 @@ export class SendFormComponent implements OnInit, OnDestroy {
   form: FormGroup;
   wallets: Wallet[];
   transactions = [];
+  currentCoin: BaseCoin;
 
   private subscription: ISubscription;
+  private coinSubscription: ISubscription;
 
   constructor(
     private formBuilder: FormBuilder,
     private walletService: WalletService,
     private snackbar: MatSnackBar,
-    private unlockDialog: MatDialog
+    private unlockDialog: MatDialog,
+    private coinService: CoinService
   ) {}
 
   ngOnInit() {
@@ -38,10 +43,14 @@ export class SendFormComponent implements OnInit, OnDestroy {
 
     this.walletService.all
       .subscribe(wallets => this.wallets = wallets);
+
+    this.coinSubscription = this.coinService.currentCoin
+      .subscribe((coin: BaseCoin) => this.currentCoin = coin);
   }
 
   ngOnDestroy() {
     this.subscription.unsubscribe();
+    this.coinSubscription.unsubscribe();
     this.snackbar.dismiss();
   }
 

--- a/src/app/components/pages/send-skycoin/send-verify/transaction-info/transaction-info.component.html
+++ b/src/app/components/pages/send-skycoin/send-verify/transaction-info/transaction-info.component.html
@@ -35,7 +35,7 @@
         <div class="-icon" [ngClass]="{ '-incoming': !isPreview && transaction.balance > 0 }">
           <img src="/assets/img/send-blue.png">
         </div>
-        <h4>{{ transaction.balance | number:'1.0-6' }} {{ 'common.coin-id' | translate }}</h4>
+        <h4>{{ transaction.balance | number:'1.0-6' }} {{ currentCoin.coinSymbol }}</h4>
         <p *ngIf="price" [matTooltip]="!isPreview ? ('history.price-tooltip' | translate) : ''">
           {{ transaction.balance * price | currency:'USD':'symbol':'1.2-2' }}<span *ngIf="!isPreview">*</span>
         </p>

--- a/src/app/components/pages/send-skycoin/send-verify/transaction-info/transaction-info.component.spec.ts
+++ b/src/app/components/pages/send-skycoin/send-verify/transaction-info/transaction-info.component.spec.ts
@@ -5,6 +5,8 @@ import { BehaviorSubject } from 'rxjs/BehaviorSubject';
 
 import { TransactionInfoComponent } from './transaction-info.component';
 import { PriceService } from '../../../../../services/price.service';
+import { BaseCoin } from '../../../../../coins/basecoin';
+import { CoinService } from '../../../../../services/coin.service';
 
 @Pipe({name: 'translate'})
 class MockTranslatePipe implements PipeTransform {
@@ -17,6 +19,17 @@ class MockPriceService {
   price: Subject<number> = new BehaviorSubject<number>(null);
 }
 
+class MockCoinService {
+  currentCoin = new BehaviorSubject<BaseCoin>({
+    id: 1,
+    nodeUrl: 'nodeUrl',
+    nodeVersion: 'v1',
+    coinName: 'test coin',
+    coinSymbol: 'test',
+    hoursName: 'test'
+  });
+}
+
 describe('TransactionInfoComponent', () => {
   let component: TransactionInfoComponent;
   let fixture: ComponentFixture<TransactionInfoComponent>;
@@ -26,7 +39,8 @@ describe('TransactionInfoComponent', () => {
       declarations: [ TransactionInfoComponent, MockTranslatePipe ],
       schemas: [ NO_ERRORS_SCHEMA ],
       providers: [
-        { provide: PriceService, useClass: MockPriceService }
+        { provide: PriceService, useClass: MockPriceService },
+        { provide: CoinService, useClass: MockCoinService }
       ]
     })
     .compileComponents();

--- a/src/app/components/pages/send-skycoin/send-verify/transaction-info/transaction-info.component.spec.ts
+++ b/src/app/components/pages/send-skycoin/send-verify/transaction-info/transaction-info.component.spec.ts
@@ -26,7 +26,8 @@ class MockCoinService {
     nodeVersion: 'v1',
     coinName: 'test coin',
     coinSymbol: 'test',
-    hoursName: 'test'
+    hoursName: 'test',
+    cmcTickerId: 1
   });
 }
 

--- a/src/app/components/pages/send-skycoin/send-verify/transaction-info/transaction-info.component.ts
+++ b/src/app/components/pages/send-skycoin/send-verify/transaction-info/transaction-info.component.ts
@@ -3,6 +3,8 @@ import { ISubscription } from 'rxjs/Subscription';
 
 import { Transaction } from '../../../../../app.datatypes';
 import { PriceService } from '../../../../../services/price.service';
+import { CoinService } from '../../../../../services/coin.service';
+import { BaseCoin } from '../../../../../coins/basecoin';
 
 @Component({
   selector: 'app-transaction-info',
@@ -14,19 +16,27 @@ export class TransactionInfoComponent implements OnInit, OnDestroy {
   @Input() isPreview: boolean;
   price: number;
   showInputsOutputs = false;
+  currentCoin: BaseCoin;
 
   private subscription: ISubscription;
+  private coinSubscription: ISubscription;
 
-  constructor(private priceService: PriceService) {
-  }
+  constructor(
+    private priceService: PriceService,
+    private coinService: CoinService
+  ) {}
 
   ngOnInit() {
     this.subscription = this.priceService.price
       .subscribe(price => this.price = price);
+
+    this.coinSubscription = this.coinService.currentCoin
+      .subscribe((coin: BaseCoin) => this.currentCoin = coin);
   }
 
   ngOnDestroy() {
     this.subscription.unsubscribe();
+    this.coinSubscription.unsubscribe();
   }
 
   toggleInputsOutputs(event) {

--- a/src/app/components/pages/settings/outputs/outputs.component.html
+++ b/src/app/components/pages/settings/outputs/outputs.component.html
@@ -5,8 +5,8 @@
     <div class="-table" *ngFor="let wallet of wallets">
       <div class="-headers">
         <div class="flex-fill">{{ wallet.label }}</div>
-        <div class="-width-150 -text-right">{{ 'common.coin-id' | translate }}</div>
-        <div class="-width-150 -text-right">{{ 'common.coin-hours' | translate }}</div>
+        <div class="-width-150 -text-right">{{ currentCoin.coinSymbol }}</div>
+        <div class="-width-150 -text-right">{{ currentCoin.hoursName }}</div>
       </div>
       <div class="-body">
         <ng-container *ngFor="let address of wallet.addresses">

--- a/src/app/components/pages/settings/outputs/outputs.component.spec.ts
+++ b/src/app/components/pages/settings/outputs/outputs.component.spec.ts
@@ -3,14 +3,21 @@ import { NO_ERRORS_SCHEMA, Pipe, PipeTransform } from '@angular/core';
 import { Observable } from 'rxjs/Observable';
 import { ActivatedRoute } from '@angular/router';
 import { MatDialogModule } from '@angular/material';
+import { BehaviorSubject } from 'rxjs/BehaviorSubject';
 
 import { OutputsComponent } from './outputs.component';
 import { WalletService } from '../../../../services/wallet.service';
+import { BaseCoin } from '../../../../coins/basecoin';
+import { CoinService } from '../../../../services/coin.service';
 
 class MockWalletService {
   outputsWithWallets() {
     return Observable.of([]);
   }
+}
+
+class MockCoinService {
+  currentCoin = new BehaviorSubject<BaseCoin>(null);
 }
 
 @Pipe({name: 'translate'})
@@ -31,7 +38,8 @@ describe('OutputsComponent', () => {
       schemas: [ NO_ERRORS_SCHEMA ],
       providers: [
         { provide: ActivatedRoute, useValue: { queryParams: Observable.of({}) } },
-        { provide: WalletService, useClass: MockWalletService }
+        { provide: WalletService, useClass: MockWalletService },
+        { provide: CoinService, useClass: MockCoinService }
       ]
     }).compileComponents();
   }));

--- a/src/app/components/pages/settings/outputs/outputs.component.ts
+++ b/src/app/components/pages/settings/outputs/outputs.component.ts
@@ -1,28 +1,42 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, OnInit, OnDestroy } from '@angular/core';
 import { ActivatedRoute, Params } from '@angular/router';
 import { MatDialog, MatDialogConfig } from '@angular/material';
 
 import { WalletService } from '../../../../services/wallet.service';
 import { Wallet } from '../../../../app.datatypes';
 import { QrCodeComponent } from '../../../layout/qr-code/qr-code.component';
+import { BaseCoin } from '../../../../coins/basecoin';
+import { CoinService } from '../../../../services/coin.service';
+import { ISubscription } from 'rxjs/Subscription';
 
 @Component({
   selector: 'app-outputs',
   templateUrl: './outputs.component.html',
   styleUrls: ['./outputs.component.scss']
 })
-export class OutputsComponent implements OnInit {
+export class OutputsComponent implements OnInit, OnDestroy {
 
   wallets: Wallet[];
+  currentCoin: BaseCoin;
+
+  private coinSubscription: ISubscription;
 
   constructor(
     private route: ActivatedRoute,
     private walletService: WalletService,
-    private dialog: MatDialog
+    private dialog: MatDialog,
+    private coinService: CoinService
   ) { }
 
   ngOnInit() {
     this.route.queryParams.subscribe(params => this.getWalletsOutputs(params));
+
+    this.coinSubscription = this.coinService.currentCoin
+      .subscribe((coin: BaseCoin) => this.currentCoin = coin);
+  }
+
+  ngOnDestroy() {
+    this.coinSubscription.unsubscribe();
   }
 
   showQr(address) {

--- a/src/app/components/pages/settings/pending-transactions/pending-transactions.component.html
+++ b/src/app/components/pages/settings/pending-transactions/pending-transactions.component.html
@@ -5,7 +5,7 @@
     <div *ngIf="!!transactions && transactions.length > 0" class="-table">
       <div class="-headers">
         <div class="flex-fill">{{ 'pending-txs.txid' | translate }}</div>
-        <div class="-width-150">{{ 'common.coin-id' | translate }}</div>
+        <div class="-width-150">{{ currentCoin.coinSymbol }}</div>
         <div class="-width-150">{{ 'pending-txs.timestamp' | translate }}</div>
       </div>
       <div class="-body">

--- a/src/app/components/pages/settings/pending-transactions/pending-transactions.component.spec.ts
+++ b/src/app/components/pages/settings/pending-transactions/pending-transactions.component.spec.ts
@@ -7,6 +7,8 @@ import { PendingTransactionsComponent } from './pending-transactions.component';
 import { WalletService } from '../../../../services/wallet.service';
 import { NavBarService } from '../../../../services/nav-bar.service';
 import { Wallet } from '../../../../app.datatypes';
+import { BaseCoin } from '../../../../coins/basecoin';
+import { CoinService } from '../../../../services/coin.service';
 
 class MockWalletService {
   get all(): Observable<Wallet[]> {
@@ -28,6 +30,10 @@ class MockNavBarService {
   showSwitch(leftText: any, rightText: any) {}
 
   hideSwitch() {}
+}
+
+class MockCoinService {
+  currentCoin = new BehaviorSubject<BaseCoin>(null);
 }
 
 @Pipe({name: 'translate'})
@@ -58,7 +64,8 @@ describe('PendingTransactionsComponent', () => {
       schemas: [ NO_ERRORS_SCHEMA ],
       providers: [
         { provide: WalletService, useClass: MockWalletService },
-        { provide: NavBarService, useClass: MockNavBarService }
+        { provide: NavBarService, useClass: MockNavBarService },
+        { provide: CoinService, useClass: MockCoinService }
       ]
     }).compileComponents();
   }));

--- a/src/app/components/pages/settings/pending-transactions/pending-transactions.component.ts
+++ b/src/app/components/pages/settings/pending-transactions/pending-transactions.component.ts
@@ -7,6 +7,8 @@ import { NavBarService } from '../../../../services/nav-bar.service';
 import { DoubleButtonActive } from '../../../layout/double-button/double-button.component';
 import { Wallet } from '../../../../app.datatypes';
 import { Observable } from 'rxjs/Observable';
+import { BaseCoin } from '../../../../coins/basecoin';
+import { CoinService } from '../../../../services/coin.service';
 
 @Component({
   selector: 'app-pending-transactions',
@@ -17,11 +19,14 @@ export class PendingTransactionsComponent implements OnInit, OnDestroy {
 
   isLoading = false;
   transactions: any[] = [];
+  currentCoin: BaseCoin;
   private navbarSubscription: ISubscription;
+  private coinSubscription: ISubscription;
 
   constructor(
     private walletService: WalletService,
-    private navbarService: NavBarService
+    private navbarService: NavBarService,
+    private coinService: CoinService
   ) { }
 
   ngOnInit() {
@@ -30,10 +35,14 @@ export class PendingTransactionsComponent implements OnInit, OnDestroy {
     this.navbarSubscription = this.navbarService.activeComponent.subscribe(value => {
       this.loadTransactions(value);
     });
+
+    this.coinSubscription = this.coinService.currentCoin
+      .subscribe((coin: BaseCoin) => this.currentCoin = coin);
   }
 
   ngOnDestroy() {
     this.navbarSubscription.unsubscribe();
+    this.coinSubscription.unsubscribe();
     this.navbarService.hideSwitch();
   }
 

--- a/src/app/components/pages/wallets/wallets.component.html
+++ b/src/app/components/pages/wallets/wallets.component.html
@@ -4,8 +4,8 @@
     <div class="-headers">
       <div class="-width-250">{{ 'wallet.wallet' | translate }}</div>
       <div class="flex-fill">{{ 'wallet.encryption' | translate }}</div>
-      <div class="-width-150 -align-right">{{ 'common.coin-id' | translate }}</div>
-      <div class="-width-150 -align-right">{{ 'common.coin-hours' | translate }}</div>
+      <div class="-width-150 -align-right">{{ currentCoin.coinSymbol }}</div>
+      <div class="-width-150 -align-right">{{ currentCoin.hoursName }}</div>
     </div>
     <div class="-wallets">
       <ng-container *ngFor="let wallet of wallets">

--- a/src/app/components/pages/wallets/wallets.component.spec.ts
+++ b/src/app/components/pages/wallets/wallets.component.spec.ts
@@ -23,7 +23,8 @@ class MockCoinService {
     nodeVersion: 'v1',
     coinName: 'test coin',
     coinSymbol: 'test',
-    hoursName: 'test'
+    hoursName: 'test',
+    cmcTickerId: 1
   });
 }
 

--- a/src/app/components/pages/wallets/wallets.component.spec.ts
+++ b/src/app/components/pages/wallets/wallets.component.spec.ts
@@ -2,15 +2,29 @@ import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { NO_ERRORS_SCHEMA, Pipe, PipeTransform } from '@angular/core';
 import { MatDialog } from '@angular/material';
 import { Observable } from 'rxjs/Observable';
+import { BehaviorSubject } from 'rxjs/BehaviorSubject';
 
 import { WalletsComponent } from './wallets.component';
 import { WalletService } from '../../../services/wallet.service';
 import { Wallet } from '../../../app.datatypes';
+import { BaseCoin } from '../../../coins/basecoin';
+import { CoinService } from '../../../services/coin.service';
 
 class MockWalletService {
   get all(): Observable<Wallet[]> {
     return Observable.of([]);
   }
+}
+
+class MockCoinService {
+  currentCoin = new BehaviorSubject<BaseCoin>({
+    id: 1,
+    nodeUrl: 'nodeUrl',
+    nodeVersion: 'v1',
+    coinName: 'test coin',
+    coinSymbol: 'test',
+    hoursName: 'test'
+  });
 }
 
 @Pipe({name: 'translate'})
@@ -30,7 +44,8 @@ describe('WalletsComponent', () => {
       schemas: [ NO_ERRORS_SCHEMA ],
       providers: [
         { provide: WalletService, useClass: MockWalletService },
-        { provide: MatDialog, useValue: {} }
+        { provide: MatDialog, useValue: {} },
+        { provide: CoinService, useClass: MockCoinService }
       ]
     })
     .compileComponents();

--- a/src/app/components/pages/wallets/wallets.component.ts
+++ b/src/app/components/pages/wallets/wallets.component.ts
@@ -1,29 +1,43 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, OnInit, OnDestroy } from '@angular/core';
 import { MatDialog, MatDialogConfig } from '@angular/material/dialog';
 
 import { Wallet } from '../../../app.datatypes';
 import { WalletService } from '../../../services/wallet.service';
 import { CreateWalletComponent } from './create-wallet/create-wallet.component';
 import { openUnlockWalletModal } from '../../../utils/index';
+import { CoinService } from '../../../services/coin.service';
+import { BaseCoin } from '../../../coins/basecoin';
+import { ISubscription } from 'rxjs/Subscription';
 
 @Component({
   selector: 'app-wallets',
   templateUrl: './wallets.component.html',
   styleUrls: ['./wallets.component.scss'],
 })
-export class WalletsComponent implements OnInit {
+export class WalletsComponent implements OnInit, OnDestroy {
 
   wallets: Wallet[];
+  currentCoin: BaseCoin;
+
+  private coinSubscription: ISubscription;
 
   constructor(
     private walletService: WalletService,
-    private dialog: MatDialog
+    private dialog: MatDialog,
+    private coinService: CoinService
   ) {}
 
   ngOnInit() {
     this.walletService.all.subscribe( (wallets) => {
       this.wallets = wallets;
     });
+
+    this.coinSubscription = this.coinService.currentCoin
+      .subscribe((coin: BaseCoin) => this.currentCoin = coin);
+  }
+
+  ngOnDestroy() {
+    this.coinSubscription.unsubscribe();
   }
 
   addWallet(create: boolean) {

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -1,8 +1,5 @@
 {
   "common": {
-    "coin-id": "SKY",
-    "coin-hours": "Coin Hours",
-    "hours": "Hours",
     "loading": "Loading..",
     "new": "New",
     "load": "Load",
@@ -43,10 +40,8 @@
     "pending-txs2": "pending transactions.",
     "pending-txs3": "Data you see may not be updated.",
     "loading": "Loading...",
-    "coin-id": "sky",
     "updated1": "Updated:",
     "updated2": "min ago",
-
 
     "errors": {
       "no-connections": "No connections active, web client is not connected to any other nodes!",


### PR DESCRIPTION
Fixes #334 

Changes:
- show coin symbol from coin service instead of translated text;
- show hours name from coin service instead of translated text;
- fix appropriate unit-tests;
- removed unused text from `en.json`.
