### PR TITLE
#349: Show the name of the selected coin

### DIFF
--- a/src/app/coins/basecoin.ts
+++ b/src/app/coins/basecoin.ts
@@ -6,6 +6,7 @@ export abstract class BaseCoin {
   coinSymbol: string;
   hoursName: string;
   cmcTickerId: number;
+  coinExplorer: string;
 
   constructor(coinObj) {
     Object.assign(this, coinObj);

--- a/src/app/coins/skycoin.coin.ts
+++ b/src/app/coins/skycoin.coin.ts
@@ -11,7 +11,8 @@ export class SkycoinCoin extends BaseCoin {
       coinName: 'Skycoin',
       coinSymbol: 'SKY',
       hoursName: 'Coin Hours',
-      cmcTickerId: 1619
+      cmcTickerId: 1619,
+      coinExplorer: 'https://explorer.skycoin.net'
     });
   }
 }

--- a/src/app/coins/test.coin.ts
+++ b/src/app/coins/test.coin.ts
@@ -11,7 +11,8 @@ export class TestCoin extends BaseCoin {
       coinName: 'Testcoin',
       coinSymbol: 'TEST',
       hoursName: 'Test Hours',
-      cmcTickerId: 1
+      cmcTickerId: 1,
+      coinExplorer: 'https://explorer.testcoin.net'
     });
   }
 }

--- a/src/app/components/layout/header/header.component.html
+++ b/src/app/components/layout/header/header.component.html
@@ -2,7 +2,7 @@
   <app-disclaimer-warning></app-disclaimer-warning>
 
   <div class="-select-coin">
-    <span>Choose coin:</span>
+    <span>{{ 'header.choose-coin' | translate }}</span>
     <div class="-select">
       <app-select-coin [selectedCoin]="currentCoin" (onCoinChanged)="onCoinChanged($event)"></app-select-coin>
     </div>

--- a/src/app/components/layout/header/top-bar/top-bar.component.html
+++ b/src/app/components/layout/header/top-bar/top-bar.component.html
@@ -21,7 +21,9 @@
   </mat-menu>
 
   <mat-menu #menuMenu="matMenu" [overlapTrigger]="false">
-    <a mat-menu-item href="https://explorer.skycoin.net" class="color-primary"> {{ 'title.explorer' | translate}} </a>
+    <a mat-menu-item [href]="currentCoin.coinExplorer" class="color-primary">
+      {{ currentCoin.coinName }} {{ 'title.explorer' | translate}}
+    </a>
   </mat-menu>
 
   <button mat-icon-button [matMenuTriggerFor]="settingsMenu">

--- a/src/app/components/layout/header/top-bar/top-bar.component.spec.ts
+++ b/src/app/components/layout/header/top-bar/top-bar.component.spec.ts
@@ -8,6 +8,8 @@ import { BehaviorSubject } from 'rxjs/BehaviorSubject';
 import { TopBarComponent } from './top-bar.component';
 import { WalletService } from '../../../../services/wallet.service';
 import { TotalBalance } from '../../../../app.datatypes';
+import { BaseCoin } from '../../../../coins/basecoin';
+import { CoinService } from '../../../../services/coin.service';
 
 @Pipe({name: 'translate'})
 class MockTranslatePipe implements PipeTransform {
@@ -26,6 +28,19 @@ class MockWalletService {
   }
 }
 
+class MockCoinService {
+  currentCoin = new BehaviorSubject<BaseCoin>({
+    id: 1,
+    nodeUrl: 'nodeUrl',
+    nodeVersion: 'v1',
+    coinName: 'test coin',
+    coinSymbol: 'test',
+    hoursName: 'test',
+    cmcTickerId: 1,
+    coinExplorer: 'testUrl'
+  });
+}
+
 describe('TopBarComponent', () => {
   let component: TopBarComponent;
   let fixture: ComponentFixture<TopBarComponent>;
@@ -40,7 +55,8 @@ describe('TopBarComponent', () => {
         RouterTestingModule
       ],
       providers: [
-        { provide: WalletService, useClass: MockWalletService }
+        { provide: WalletService, useClass: MockWalletService },
+        { provide: CoinService, useClass: MockCoinService }
       ]
     })
     .compileComponents();

--- a/src/app/components/layout/header/top-bar/top-bar.component.ts
+++ b/src/app/components/layout/header/top-bar/top-bar.component.ts
@@ -3,6 +3,8 @@ import { Subscription } from 'rxjs/Subscription';
 
 import { WalletService } from '../../../../services/wallet.service';
 import { TotalBalance } from '../../../../app.datatypes';
+import { CoinService } from '../../../../services/coin.service';
+import { BaseCoin } from '../../../../coins/basecoin';
 
 @Component({
   selector: 'app-top-bar',
@@ -15,9 +17,13 @@ export class TopBarComponent implements OnInit, OnDestroy {
   timeSinceLastUpdateBalances = 0;
   isBalanceObtained = false;
   isBalanceUpdated: boolean;
-  private updateBalancesSubscription: Subscription;
+  currentCoin: BaseCoin;
 
-  constructor(private walletService: WalletService) {
+  private updateBalancesSubscription: Subscription;
+  private coinSubscription: Subscription;
+
+  constructor(private walletService: WalletService,
+              private coinService: CoinService) {
   }
 
   ngOnInit() {
@@ -36,9 +42,13 @@ export class TopBarComponent implements OnInit, OnDestroy {
           this.timeSinceLastUpdateBalances = time;
         }
       });
+
+    this.coinSubscription = this.coinService.currentCoin
+      .subscribe((coin: BaseCoin) => this.currentCoin = coin);
   }
 
   ngOnDestroy() {
     this.updateBalancesSubscription.unsubscribe();
+    this.coinSubscription.unsubscribe();
   }
 }

--- a/src/app/components/pages/send-skycoin/send-form/send-form.component.spec.ts
+++ b/src/app/components/pages/send-skycoin/send-form/send-form.component.spec.ts
@@ -32,7 +32,8 @@ class MockCoinService {
     coinName: 'test coin',
     coinSymbol: 'test',
     hoursName: 'test',
-    cmcTickerId: 1
+    cmcTickerId: 1,
+    coinExplorer: 'testUrl'
   });
 }
 

--- a/src/app/components/pages/send-skycoin/send-verify/transaction-info/transaction-info.component.spec.ts
+++ b/src/app/components/pages/send-skycoin/send-verify/transaction-info/transaction-info.component.spec.ts
@@ -27,7 +27,8 @@ class MockCoinService {
     coinName: 'test coin',
     coinSymbol: 'test',
     hoursName: 'test',
-    cmcTickerId: 1
+    cmcTickerId: 1,
+    coinExplorer: 'testUrl'
   });
 }
 

--- a/src/app/components/pages/settings/blockchain/blockchain.component.html
+++ b/src/app/components/pages/settings/blockchain/blockchain.component.html
@@ -24,21 +24,29 @@
           <div class="row">
             <div class="col-md-6">
               <div class="-item">
-                <div class="-key">{{ 'blockchain.current-supply' | translate }}</div>
+                <div class="-key">
+                  {{ 'blockchain.current-supply1' | translate }} {{ currentCoin.coinSymbol }} {{ 'blockchain.current-supply2' | translate }}
+                </div>
                 <div class="-value">{{ coinSupply.current_supply | number }}</div>
               </div>
               <div class="-item">
-                <div class="-key">{{ 'blockchain.total-supply' | translate }}</div>
+                <div class="-key">
+                  {{ 'blockchain.total-supply1' | translate }} {{ currentCoin.coinSymbol }} {{ 'blockchain.total-supply2' | translate }}
+                </div>
                 <div class="-value">{{ coinSupply.total_supply | number }}</div>
               </div>
             </div>
             <div class="col-md-6">
               <div class="-item">
-                <div class="-key">{{ 'blockchain.current-coinhour-supply' | translate }}</div>
+                <div class="-key">
+                  {{ 'blockchain.current-supply1' | translate }} {{ currentCoin.hoursName }} {{ 'blockchain.current-supply2' | translate }}
+                </div>
                 <div class="-value">{{ coinSupply.current_coinhour_supply | number }}</div>
               </div>
               <div class="-item">
-                <div class="-key">{{ 'blockchain.total-coinhour-supply' | translate }}</div>
+                <div class="-key">
+                  {{ 'blockchain.total-supply1' | translate }} {{ currentCoin.hoursName }} {{ 'blockchain.total-supply2' | translate }}
+                </div>
                 <div class="-value">{{ coinSupply.total_coinhour_supply | number }}</div>
               </div>
             </div>

--- a/src/app/components/pages/settings/blockchain/blockchain.component.spec.ts
+++ b/src/app/components/pages/settings/blockchain/blockchain.component.spec.ts
@@ -2,8 +2,11 @@ import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { BlockchainComponent } from './blockchain.component';
 import { NO_ERRORS_SCHEMA, Pipe, PipeTransform } from '@angular/core';
 import { Observable } from 'rxjs/Observable';
+import { BehaviorSubject } from 'rxjs/BehaviorSubject';
 
 import { BlockchainService } from '../../../../services/blockchain.service';
+import { BaseCoin } from '../../../../coins/basecoin';
+import { CoinService } from '../../../../services/coin.service';
 
 @Pipe({name: 'dateFromNow'})
 class MockDateFromNowPipe implements PipeTransform {
@@ -29,6 +32,19 @@ class MockBlockchainService {
   }
 }
 
+class MockCoinService {
+  currentCoin = new BehaviorSubject<BaseCoin>({
+    id: 1,
+    nodeUrl: 'nodeUrl',
+    nodeVersion: 'v1',
+    coinName: 'test coin',
+    coinSymbol: 'test',
+    hoursName: 'test',
+    cmcTickerId: 1,
+    coinExplorer: 'testUrl'
+  });
+}
+
 describe('BlockchainComponent', () => {
   let component: BlockchainComponent;
   let fixture: ComponentFixture<BlockchainComponent>;
@@ -42,7 +58,8 @@ describe('BlockchainComponent', () => {
       ],
       schemas: [ NO_ERRORS_SCHEMA ],
       providers: [
-        { provide: BlockchainService, useClass: MockBlockchainService }
+        { provide: BlockchainService, useClass: MockBlockchainService },
+        { provide: CoinService, useClass: MockCoinService }
       ]
     }).compileComponents();
   }));

--- a/src/app/components/pages/settings/blockchain/blockchain.component.ts
+++ b/src/app/components/pages/settings/blockchain/blockchain.component.ts
@@ -1,18 +1,25 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, OnDestroy, OnInit } from '@angular/core';
+import { Subscription } from 'rxjs/Subscription';
 
 import { BlockchainService } from '../../../../services/blockchain.service';
 import { Observable } from 'rxjs/Observable';
+import { CoinService } from '../../../../services/coin.service';
+import { BaseCoin } from '../../../../coins/basecoin';
 
 @Component({
   templateUrl: './blockchain.component.html',
   styleUrls: ['./blockchain.component.scss']
 })
-export class BlockchainComponent implements OnInit {
+export class BlockchainComponent implements OnInit, OnDestroy {
   block: any;
   coinSupply: any;
+  currentCoin: BaseCoin;
+
+  private coinSubscription: Subscription;
 
   constructor(
     private blockchainService: BlockchainService,
+    private coinService: CoinService
   ) { }
 
   ngOnInit() {
@@ -24,5 +31,12 @@ export class BlockchainComponent implements OnInit {
       this.block = block;
       this.coinSupply = coinSupply;
     });
+
+    this.coinSubscription = this.coinService.currentCoin
+      .subscribe((coin: BaseCoin) => this.currentCoin = coin);
+  }
+
+  ngOnDestroy() {
+    this.coinSubscription.unsubscribe();
   }
 }

--- a/src/app/components/pages/wallets/wallets.component.spec.ts
+++ b/src/app/components/pages/wallets/wallets.component.spec.ts
@@ -24,7 +24,8 @@ class MockCoinService {
     coinName: 'test coin',
     coinSymbol: 'test',
     hoursName: 'test',
-    cmcTickerId: 1
+    cmcTickerId: 1,
+    coinExplorer: 'testUrl'
   });
 }
 

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -26,7 +26,7 @@
     "transactions": "Transactions",
     "pending-txs": "Pending Transactions",
     "backup": "Backup Wallet",
-    "explorer": "Skycoin Explorer",
+    "explorer": "Explorer",
     "seed": "Wallet Seed",
     "qrcode": "QR Code",
     "disclaimer": "Disclaimer",
@@ -43,6 +43,7 @@
     "loading": "Loading...",
     "updated1": "Updated:",
     "updated2": "min ago",
+    "choose-coin": "Choose coin:",
 
     "errors": {
       "no-connections": "No connections active, web client is not connected to any other nodes!",
@@ -87,7 +88,7 @@
   },
 
   "wizard": {
-    "wallet-desc": "If you don't have a Skycoin wallet, use the generated seed to create a new one. If you already have a wallet, toggle over to \"Load Wallet\" and enter your seed.",
+    "wallet-desc": "If you don't have a wallet, use the generated seed to create a new one. If you already have a wallet, toggle over to \"Load Wallet\" and enter your seed.",
     "encrypt-desc": "Increase security of your wallet by encrypting it. By entering a password below, your wallet will be encrypted. Only those with the password will be able access the wallet and remove funds.",
     "finish-button": "Finish",
     "skip-button": "Skip",
@@ -208,10 +209,10 @@
     "blocks": "Number of blocks:",
     "time": "Time since last block:",
     "hash": "Hash of last block:",
-    "current-supply": "Current SKY supply",
-    "total-supply": "Total SKY supply",
-    "current-coinhour-supply": "Current Coin Hours supply",
-    "total-coinhour-supply": "Total Coin Hours supply"
+    "current-supply1": "Current",
+    "current-supply2": "supply",
+    "total-supply1": "Total",
+    "total-supply2": "supply"
   },
 
   "network": {


### PR DESCRIPTION
Fixes #349 

Changes:
- "coinExplorer" property has been added to the "BaseCoin" class
- Link to coin explorer has been added to the "sky" and "test" coins
- Header's "Choose coin:" hard code has been replaced with the translated version
- "CoinService" has been used to replace "SKY" and "Coin" hours to appropriate coin entities
- Fixed unit tests
 


