### PR TITLE
#354: Bug if more than one wallet has the same seed

### DIFF
--- a/src/app/services/wallet.service.ts
+++ b/src/app/services/wallet.service.ts
@@ -174,7 +174,8 @@ export class WalletService {
 
   updateWallet(wallet: Wallet, shouldSave: boolean = true) {
     this.wallets.first().subscribe(wallets => {
-      const index = wallets.findIndex(w => w.addresses[0].address === wallet.addresses[0].address);
+      const index = wallets.findIndex(wlt =>
+        wlt.addresses[0].address === wallet.addresses[0].address && wlt.coinId === wallet.coinId);
 
       if (index === -1) {
         throw new Error(this.translate.instant('service.wallet.unknown-address'));


### PR DESCRIPTION
Fixes #354 

Changes:
- Filtering of wallets has been fixed considering usage of different coins.
