### PR TITLE
#346: Move all mock classes into one place

### DIFF
--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -1,21 +1,9 @@
 import { TestBed, async, ComponentFixture } from '@angular/core/testing';
 import { NO_ERRORS_SCHEMA } from '@angular/core';
 import { TranslateService } from '@ngx-translate/core';
-import { Observable } from 'rxjs/Observable';
 
 import { AppComponent } from './app.component';
-
-class MockTranslateService {
-  addLangs(langs: Array<string>): void {
-  }
-
-  setDefaultLang(lang: string): void {
-  }
-
-  use(lang: string): Observable<any> {
-    return Observable.of({});
-  }
-}
+import { MockTranslateService } from './utils/test-mocks';
 
 describe('AppComponent', () => {
   let component: AppComponent;

--- a/src/app/components/layout/disclaimer-warning/disclaimer-warning.component.spec.ts
+++ b/src/app/components/layout/disclaimer-warning/disclaimer-warning.component.spec.ts
@@ -1,21 +1,9 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
-import { NO_ERRORS_SCHEMA, Pipe, PipeTransform } from '@angular/core';
+import { NO_ERRORS_SCHEMA } from '@angular/core';
 
 import { DisclaimerWarningComponent } from './disclaimer-warning.component';
 import { FeatureService } from '../../../services/feature.service';
-
-@Pipe({name: 'translate'})
-class MockTranslatePipe implements PipeTransform {
-  transform() {
-    return 'translated value';
-  }
-}
-
-class MockFeatureService {
-  getFeatureToggleData(): any {
-    return {};
-  }
-}
+import { MockTranslatePipe, MockFeatureService } from '../../../utils/test-mocks';
 
 describe('DisclaimerWarningComponent', () => {
   let component: DisclaimerWarningComponent;

--- a/src/app/components/layout/double-button/double-button.component.spec.ts
+++ b/src/app/components/layout/double-button/double-button.component.spec.ts
@@ -1,14 +1,8 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
-import { NO_ERRORS_SCHEMA, Pipe, PipeTransform } from '@angular/core';
+import { NO_ERRORS_SCHEMA } from '@angular/core';
 
 import { DoubleButtonComponent } from './double-button.component';
-
-@Pipe({name: 'translate'})
-class MockTranslatePipe implements PipeTransform {
-  transform() {
-    return 'translated value';
-  }
-}
+import { MockTranslatePipe } from '../../../utils/test-mocks';
 
 describe('DoubleButtonComponent', () => {
   let component: DoubleButtonComponent;

--- a/src/app/components/layout/header/header.component.spec.ts
+++ b/src/app/components/layout/header/header.component.spec.ts
@@ -1,46 +1,12 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
-import { NO_ERRORS_SCHEMA, Pipe, PipeTransform } from '@angular/core';
-import { Subject } from 'rxjs/Subject';
-import { BehaviorSubject } from 'rxjs/BehaviorSubject';
-import { Observable } from 'rxjs/Observable';
-import { ReplaySubject } from 'rxjs/ReplaySubject';
+import { NO_ERRORS_SCHEMA } from '@angular/core';
 
 import { HeaderComponent } from './header.component';
 import { PriceService } from '../../../services/price.service';
 import { WalletService } from '../../../services/wallet.service';
 import { BlockchainService } from '../../../services/blockchain.service';
-import { TotalBalance } from '../../../app.datatypes';
 import { CoinService } from '../../../services/coin.service';
-import { BaseCoin } from '../../../coins/basecoin';
-
-class MockPriceService {
-  price: Subject<number> = new BehaviorSubject<number>(null);
-}
-
-class MockWalletService {
-  totalBalance: Subject<TotalBalance> = new BehaviorSubject<TotalBalance>(null);
-  hasPendingTransactions: Subject<boolean> = new ReplaySubject<boolean>();
-
-  sum() {
-  }
-}
-
-class MockBlockchainService {
-  get progress() {
-    return Observable.of();
-  }
-}
-
-class MockCoinService {
-  currentCoin = new BehaviorSubject<BaseCoin>(null);
-}
-
-@Pipe({name: 'translate'})
-class MockTranslatePipe implements PipeTransform {
-  transform() {
-    return 'translated value';
-  }
-}
+import { MockTranslatePipe, MockCoinService, MockBlockchainService, MockPriceService, MockWalletService } from '../../../utils/test-mocks';
 
 describe('HeaderComponent', () => {
   let component: HeaderComponent;

--- a/src/app/components/layout/header/nav-bar/nav-bar.component.spec.ts
+++ b/src/app/components/layout/header/nav-bar/nav-bar.component.spec.ts
@@ -1,21 +1,11 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
-import { Pipe, PipeTransform } from '@angular/core';
 import { MatIconModule, MatProgressSpinnerModule, MatTooltip } from '@angular/material';
 
 import { NavBarComponent } from './nav-bar.component';
 import { NavBarService } from '../../../../services/nav-bar.service';
 import { DoubleButtonComponent } from '../../double-button/double-button.component';
 import { ButtonComponent } from '../../button/button.component';
-
-class MockNavBarService {
-}
-
-@Pipe({name: 'translate'})
-class MockTranslatePipe implements PipeTransform {
-  transform() {
-    return 'translated value';
-  }
-}
+import { MockTranslatePipe, MockNavBarService } from '../../../../utils/test-mocks';
 
 describe('NavBarComponent', () => {
   let component: NavBarComponent;

--- a/src/app/components/layout/header/top-bar/top-bar.component.spec.ts
+++ b/src/app/components/layout/header/top-bar/top-bar.component.spec.ts
@@ -1,45 +1,11 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { RouterTestingModule } from '@angular/router/testing';
 import { MatMenuModule, MatIconModule, MatTooltipModule } from '@angular/material';
-import { Observable } from 'rxjs/Observable';
-import { Pipe, PipeTransform } from '@angular/core';
-import { BehaviorSubject } from 'rxjs/BehaviorSubject';
 
 import { TopBarComponent } from './top-bar.component';
 import { WalletService } from '../../../../services/wallet.service';
-import { TotalBalance } from '../../../../app.datatypes';
-import { BaseCoin } from '../../../../coins/basecoin';
 import { CoinService } from '../../../../services/coin.service';
-
-@Pipe({name: 'translate'})
-class MockTranslatePipe implements PipeTransform {
-  transform() {
-    return 'translated value';
-  }
-}
-
-class MockWalletService {
-  get timeSinceLastBalancesUpdate(): Observable<void> {
-    return Observable.of();
-  }
-
-  get totalBalance(): BehaviorSubject<TotalBalance> {
-    return new BehaviorSubject<TotalBalance>(null);
-  }
-}
-
-class MockCoinService {
-  currentCoin = new BehaviorSubject<BaseCoin>({
-    id: 1,
-    nodeUrl: 'nodeUrl',
-    nodeVersion: 'v1',
-    coinName: 'test coin',
-    coinSymbol: 'test',
-    hoursName: 'test',
-    cmcTickerId: 1,
-    coinExplorer: 'testUrl'
-  });
-}
+import { MockTranslatePipe, MockWalletService, MockCoinService } from '../../../../utils/test-mocks';
 
 describe('TopBarComponent', () => {
   let component: TopBarComponent;

--- a/src/app/components/layout/loading-content/loading-content.component.spec.ts
+++ b/src/app/components/layout/loading-content/loading-content.component.spec.ts
@@ -1,14 +1,8 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
-import { NO_ERRORS_SCHEMA, Pipe, PipeTransform } from '@angular/core';
+import { NO_ERRORS_SCHEMA } from '@angular/core';
 
 import { LoadingContentComponent } from './loading-content.component';
-
-@Pipe({name: 'translate'})
-class MockTranslatePipe implements PipeTransform {
-  transform() {
-    return 'translated value';
-  }
-}
+import { MockTranslatePipe } from '../../../utils/test-mocks';
 
 describe('LoadingContentComponent', () => {
   let component: LoadingContentComponent;

--- a/src/app/components/layout/modal/modal.component.spec.ts
+++ b/src/app/components/layout/modal/modal.component.spec.ts
@@ -1,14 +1,8 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
-import { Pipe, PipeTransform, NO_ERRORS_SCHEMA } from '@angular/core';
+import { NO_ERRORS_SCHEMA } from '@angular/core';
 
 import { ModalComponent } from './modal.component';
-
-@Pipe({name: 'translate'})
-class MockTranslatePipe implements PipeTransform {
-  transform() {
-    return 'translated value';
-  }
-}
+import { MockTranslatePipe } from '../../../utils/test-mocks';
 
 describe('ModalComponent', () => {
   let component: ModalComponent;

--- a/src/app/components/layout/qr-code/qr-code.component.spec.ts
+++ b/src/app/components/layout/qr-code/qr-code.component.spec.ts
@@ -1,15 +1,9 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
-import { NO_ERRORS_SCHEMA, Pipe, PipeTransform } from '@angular/core';
+import { NO_ERRORS_SCHEMA } from '@angular/core';
 import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material';
 
 import { QrCodeComponent } from './qr-code.component';
-
-@Pipe({name: 'translate'})
-class MockTranslatePipe implements PipeTransform {
-  transform() {
-    return 'translated value';
-  }
-}
+import { MockTranslatePipe } from '../../../utils/test-mocks';
 
 describe('QrCodeComponent', () => {
   let component: QrCodeComponent;

--- a/src/app/components/pages/buy/add-deposit-address/add-deposit-address.component.spec.ts
+++ b/src/app/components/pages/buy/add-deposit-address/add-deposit-address.component.spec.ts
@@ -7,22 +7,7 @@ import { Observable } from 'rxjs/Observable';
 import { AddDepositAddressComponent } from './add-deposit-address.component';
 import { WalletService } from '../../../../services/wallet.service';
 import { PurchaseService } from '../../../../services/purchase.service';
-
-class MockWalletService {
-  get addresses(): Observable<any[]> {
-    return Observable.of([]);
-  }
-}
-
-class MockPurchaseService {
-}
-
-@Pipe({name: 'translate'})
-class MockTranslatePipe implements PipeTransform {
-  transform() {
-    return 'translated value';
-  }
-}
+import { MockTranslatePipe, MockPurchaseService, MockWalletService } from '../../../../utils/test-mocks';
 
 describe('AddDepositAddressComponent', () => {
   let component: AddDepositAddressComponent;

--- a/src/app/components/pages/buy/buy.component.spec.ts
+++ b/src/app/components/pages/buy/buy.component.spec.ts
@@ -1,37 +1,9 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { MatCardModule, MatDividerModule, MatIconModule, MatListModule, MatDialogModule } from '@angular/material';
-import { Pipe, PipeTransform } from '@angular/core';
-import { Observable } from 'rxjs/Observable';
 
 import { BuyComponent } from './buy.component';
 import { PurchaseService } from '../../../services/purchase.service';
-
-class MockPurchaseService {
-  all(): Observable<any[]> {
-    return Observable.of([]);
-  }
-}
-
-@Pipe({name: 'tellerStatus'})
-class MockTellerStatusPipe implements PipeTransform {
-  transform() {
-    return 'transformed value';
-  }
-}
-
-@Pipe({ name: 'dateTime' })
-class MockDateTimePipe implements PipeTransform {
-  transform() {
-    return 'transformed value';
-  }
-}
-
-@Pipe({name: 'translate'})
-class MockTranslatePipe implements PipeTransform {
-  transform() {
-    return 'translated value';
-  }
-}
+import { MockTranslatePipe, MockPurchaseService, MockTellerStatusPipe, MockDateTimePipe } from '../../../utils/test-mocks';
 
 describe('BuyComponent', () => {
   let component: BuyComponent;

--- a/src/app/components/pages/history/history.component.spec.ts
+++ b/src/app/components/pages/history/history.component.spec.ts
@@ -1,35 +1,12 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
-import { NO_ERRORS_SCHEMA, Pipe, PipeTransform } from '@angular/core';
+import { NO_ERRORS_SCHEMA } from '@angular/core';
 import { MatDialogModule, MatDialog } from '@angular/material';
-import { BehaviorSubject } from 'rxjs/BehaviorSubject';
-import { Observable } from 'rxjs/Observable';
 
 import { HistoryComponent } from './history.component';
 import { WalletService } from '../../../services/wallet.service';
 import { PriceService } from '../../../services/price.service';
-import { BaseCoin } from '../../../coins/basecoin';
 import { CoinService } from '../../../services/coin.service';
-
-class MockWalletService {
-  transactions(): Observable<any[]> {
-    return Observable.of([]);
-  }
-}
-
-class MockPriceService {
-  price: BehaviorSubject<number> = new BehaviorSubject<number>(null);
-}
-
-class MockCoinService {
-  currentCoin = new BehaviorSubject<BaseCoin>(null);
-}
-
-@Pipe({name: 'translate'})
-class MockTranslatePipe implements PipeTransform {
-  transform() {
-    return 'translated value';
-  }
-}
+import { MockTranslatePipe, MockPriceService, MockCoinService, MockWalletService } from '../../../utils/test-mocks';
 
 describe('HistoryComponent', () => {
   let component: HistoryComponent;

--- a/src/app/components/pages/history/transaction-detail/transaction-detail.component.spec.ts
+++ b/src/app/components/pages/history/transaction-detail/transaction-detail.component.spec.ts
@@ -1,22 +1,10 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
-import { BehaviorSubject } from 'rxjs/BehaviorSubject';
-import { Subject } from 'rxjs/Subject';
 import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material';
-import { NO_ERRORS_SCHEMA, Pipe, PipeTransform } from '@angular/core';
+import { NO_ERRORS_SCHEMA } from '@angular/core';
 
 import { TransactionDetailComponent } from './transaction-detail.component';
 import { PriceService } from '../../../../services/price.service';
-
-class MockPriceService {
-  price: Subject<number> = new BehaviorSubject<number>(null);
-}
-
-@Pipe({name: 'translate'})
-class MockTranslatePipe implements PipeTransform {
-  transform() {
-    return 'translated value';
-  }
-}
+import { MockTranslatePipe, MockPriceService } from '../../../../utils/test-mocks';
 
 describe('TransactionDetailComponent', () => {
   let component: TransactionDetailComponent;

--- a/src/app/components/pages/onboarding/onboarding-create-wallet/onboarding-create-wallet.component.spec.ts
+++ b/src/app/components/pages/onboarding/onboarding-create-wallet/onboarding-create-wallet.component.spec.ts
@@ -1,37 +1,16 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
-import { NO_ERRORS_SCHEMA, Pipe, PipeTransform } from '@angular/core';
+import { NO_ERRORS_SCHEMA } from '@angular/core';
 import { MatDialogModule, MatSnackBarModule } from '@angular/material';
 import { RouterTestingModule } from '@angular/router/testing';
 import { FormBuilder } from '@angular/forms';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { BrowserDynamicTestingModule } from '@angular/platform-browser-dynamic/testing';
-import { Observable } from 'rxjs/Observable';
-import { BehaviorSubject } from 'rxjs/BehaviorSubject';
 
 import { OnboardingCreateWalletComponent } from './onboarding-create-wallet.component';
 import { WalletService } from '../../../../services/wallet.service';
-import { Wallet } from '../../../../app.datatypes';
 import { OnboardingDisclaimerComponent } from './onboarding-disclaimer/onboarding-disclaimer.component';
 import { CoinService } from '../../../../services/coin.service';
-import { BaseCoin } from '../../../../coins/basecoin';
-
-@Pipe({name: 'translate'})
-class MockTranslatePipe implements PipeTransform {
-  transform() {
-    return 'translated value';
-  }
-}
-
-class MockWalletService {
-  isWalletsExist: Observable<boolean> = Observable.of();
-  generateSeed(entropy) {
-    return Observable.of('');
-  }
-}
-
-class MockCoinService {
-  currentCoin = new BehaviorSubject<BaseCoin>(null);
-}
+import { MockTranslatePipe, MockWalletService, MockCoinService } from '../../../../utils/test-mocks';
 
 describe('OnboardingCreateWalletComponent', () => {
   let component: OnboardingCreateWalletComponent;

--- a/src/app/components/pages/onboarding/onboarding-create-wallet/onboarding-disclaimer/onboarding-disclaimer.component.spec.ts
+++ b/src/app/components/pages/onboarding/onboarding-create-wallet/onboarding-disclaimer/onboarding-disclaimer.component.spec.ts
@@ -1,15 +1,9 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
-import { NO_ERRORS_SCHEMA, Pipe, PipeTransform } from '@angular/core';
+import { NO_ERRORS_SCHEMA } from '@angular/core';
 import { MatDialogRef } from '@angular/material';
 
 import { OnboardingDisclaimerComponent } from './onboarding-disclaimer.component';
-
-@Pipe({name: 'translate'})
-class MockTranslatePipe implements PipeTransform {
-  transform() {
-    return 'translated value';
-  }
-}
+import { MockTranslatePipe } from '../../../../../utils/test-mocks';
 
 describe('OnboardingDisclaimerComponent', () => {
   let component: OnboardingDisclaimerComponent;

--- a/src/app/components/pages/onboarding/onboarding-create-wallet/onboarding-safeguard/onboarding-safeguard.component.spec.ts
+++ b/src/app/components/pages/onboarding/onboarding-create-wallet/onboarding-safeguard/onboarding-safeguard.component.spec.ts
@@ -1,15 +1,9 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
-import { NO_ERRORS_SCHEMA, Pipe, PipeTransform } from '@angular/core';
+import { NO_ERRORS_SCHEMA } from '@angular/core';
 import { MatDialogRef } from '@angular/material';
 
 import { OnboardingSafeguardComponent } from './onboarding-safeguard.component';
-
-@Pipe({name: 'translate'})
-class MockTranslatePipe implements PipeTransform {
-  transform() {
-    return 'translated value';
-  }
-}
+import { MockTranslatePipe } from '../../../../../utils/test-mocks';
 
 describe('OnboardingSafeguardComponent', () => {
   let component: OnboardingSafeguardComponent;

--- a/src/app/components/pages/onboarding/onboarding-encrypt-wallet/onboarding-encrypt-wallet.component.spec.ts
+++ b/src/app/components/pages/onboarding/onboarding-encrypt-wallet/onboarding-encrypt-wallet.component.spec.ts
@@ -1,17 +1,11 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { MatCheckboxModule, MatProgressSpinnerModule, MatIconModule, MatTooltipModule } from '@angular/material';
 import { FormBuilder } from '@angular/forms';
-import { NO_ERRORS_SCHEMA, Pipe, PipeTransform } from '@angular/core';
+import { NO_ERRORS_SCHEMA } from '@angular/core';
 
 import { OnboardingEncryptWalletComponent } from './onboarding-encrypt-wallet.component';
 import { ButtonComponent } from '../../../layout/button/button.component';
-
-@Pipe({name: 'translate'})
-class MockTranslatePipe implements PipeTransform {
-  transform() {
-    return 'translated value';
-  }
-}
+import { MockTranslatePipe } from '../../../../utils/test-mocks';
 
 describe('OnboardingEncryptWalletComponent', () => {
   let component: OnboardingEncryptWalletComponent;

--- a/src/app/components/pages/send-skycoin/send-form/send-form.component.spec.ts
+++ b/src/app/components/pages/send-skycoin/send-form/send-form.component.spec.ts
@@ -1,46 +1,12 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { MatSnackBarModule, MatDialog } from '@angular/material';
-import { NO_ERRORS_SCHEMA, PipeTransform, Pipe } from '@angular/core';
+import { NO_ERRORS_SCHEMA } from '@angular/core';
 import { FormBuilder } from '@angular/forms';
-import { Observable } from 'rxjs/Observable';
-import { BehaviorSubject } from 'rxjs/BehaviorSubject';
 
 import { SendFormComponent } from './send-form.component';
 import { WalletService } from '../../../../services/wallet.service';
-import { Wallet } from '../../../../app.datatypes';
-import { BaseCoin } from '../../../../coins/basecoin';
 import { CoinService } from '../../../../services/coin.service';
-
-@Pipe({name: 'translate'})
-class MockTranslatePipe implements PipeTransform {
-  transform() {
-    return 'translated value';
-  }
-}
-
-class MockWalletService {
-  get all(): Observable<Wallet[]> {
-    return Observable.of([]);
-  }
-}
-
-class MockCoinService {
-  currentCoin = new BehaviorSubject<BaseCoin>({
-    id: 1,
-    nodeUrl: 'nodeUrl',
-    nodeVersion: 'v1',
-    coinName: 'test coin',
-    coinSymbol: 'test',
-    hoursName: 'test',
-    cmcTickerId: 1,
-    coinExplorer: 'testUrl'
-  });
-}
-
-class MockMatSnackBar {
-  dismiss() {
-  }
-}
+import { MockTranslatePipe, MockWalletService, MockMatSnackBar, MockCoinService } from '../../../../utils/test-mocks';
 
 describe('SendFormComponent', () => {
   let component: SendFormComponent;

--- a/src/app/components/pages/send-skycoin/send-skycoin.component.spec.ts
+++ b/src/app/components/pages/send-skycoin/send-skycoin.component.spec.ts
@@ -1,14 +1,8 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
-import { NO_ERRORS_SCHEMA, Pipe, PipeTransform } from '@angular/core';
+import { NO_ERRORS_SCHEMA } from '@angular/core';
 
 import { SendSkycoinComponent } from './send-skycoin.component';
-
-@Pipe({name: 'translate'})
-class MockTranslatePipe implements PipeTransform {
-  transform() {
-    return 'translated value';
-  }
-}
+import { MockTranslatePipe } from '../../../utils/test-mocks';
 
 describe('SendSkycoinComponent', () => {
   let component: SendSkycoinComponent;

--- a/src/app/components/pages/send-skycoin/send-verify/send-verify.component.spec.ts
+++ b/src/app/components/pages/send-skycoin/send-verify/send-verify.component.spec.ts
@@ -1,24 +1,10 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { MatSnackBar } from '@angular/material';
-import { NO_ERRORS_SCHEMA, Pipe, PipeTransform } from '@angular/core';
+import { NO_ERRORS_SCHEMA } from '@angular/core';
 
 import { SendVerifyComponent } from './send-verify.component';
 import { WalletService } from '../../../../services/wallet.service';
-
-@Pipe({name: 'translate'})
-class MockTranslatePipe implements PipeTransform {
-  transform() {
-    return 'translated value';
-  }
-}
-
-class MockWalletService {
-}
-
-class MockMatSnackBar {
-  dismiss() {
-  }
-}
+import { MockTranslatePipe, MockWalletService, MockMatSnackBar } from '../../../../utils/test-mocks';
 
 describe('SendVerifyComponent', () => {
   let component: SendVerifyComponent;

--- a/src/app/components/pages/send-skycoin/send-verify/transaction-info/transaction-info.component.spec.ts
+++ b/src/app/components/pages/send-skycoin/send-verify/transaction-info/transaction-info.component.spec.ts
@@ -1,36 +1,10 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
-import { NO_ERRORS_SCHEMA, Pipe, PipeTransform } from '@angular/core';
-import { Subject } from 'rxjs/Subject';
-import { BehaviorSubject } from 'rxjs/BehaviorSubject';
+import { NO_ERRORS_SCHEMA } from '@angular/core';
 
 import { TransactionInfoComponent } from './transaction-info.component';
 import { PriceService } from '../../../../../services/price.service';
-import { BaseCoin } from '../../../../../coins/basecoin';
 import { CoinService } from '../../../../../services/coin.service';
-
-@Pipe({name: 'translate'})
-class MockTranslatePipe implements PipeTransform {
-  transform() {
-    return 'translated value';
-  }
-}
-
-class MockPriceService {
-  price: Subject<number> = new BehaviorSubject<number>(null);
-}
-
-class MockCoinService {
-  currentCoin = new BehaviorSubject<BaseCoin>({
-    id: 1,
-    nodeUrl: 'nodeUrl',
-    nodeVersion: 'v1',
-    coinName: 'test coin',
-    coinSymbol: 'test',
-    hoursName: 'test',
-    cmcTickerId: 1,
-    coinExplorer: 'testUrl'
-  });
-}
+import { MockTranslatePipe, MockPriceService, MockCoinService } from '../../../../../utils/test-mocks';
 
 describe('TransactionInfoComponent', () => {
   let component: TransactionInfoComponent;

--- a/src/app/components/pages/settings/blockchain/blockchain.component.spec.ts
+++ b/src/app/components/pages/settings/blockchain/blockchain.component.spec.ts
@@ -1,49 +1,10 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { BlockchainComponent } from './blockchain.component';
-import { NO_ERRORS_SCHEMA, Pipe, PipeTransform } from '@angular/core';
-import { Observable } from 'rxjs/Observable';
-import { BehaviorSubject } from 'rxjs/BehaviorSubject';
+import { NO_ERRORS_SCHEMA } from '@angular/core';
 
 import { BlockchainService } from '../../../../services/blockchain.service';
-import { BaseCoin } from '../../../../coins/basecoin';
 import { CoinService } from '../../../../services/coin.service';
-
-@Pipe({name: 'dateFromNow'})
-class MockDateFromNowPipe implements PipeTransform {
-  transform() {
-    return 'transformed value';
-  }
-}
-
-@Pipe({name: 'translate'})
-class MockTranslatePipe implements PipeTransform {
-  transform() {
-    return 'translated value';
-  }
-}
-
-class MockBlockchainService {
-  lastBlock(): Observable<any> {
-    return Observable.of({});
-  }
-
-  coinSupply(): Observable<any> {
-    return Observable.of({});
-  }
-}
-
-class MockCoinService {
-  currentCoin = new BehaviorSubject<BaseCoin>({
-    id: 1,
-    nodeUrl: 'nodeUrl',
-    nodeVersion: 'v1',
-    coinName: 'test coin',
-    coinSymbol: 'test',
-    hoursName: 'test',
-    cmcTickerId: 1,
-    coinExplorer: 'testUrl'
-  });
-}
+import { MockTranslatePipe, MockCoinService, MockDateFromNowPipe, MockBlockchainService } from '../../../../utils/test-mocks';
 
 describe('BlockchainComponent', () => {
   let component: BlockchainComponent;

--- a/src/app/components/pages/settings/outputs/outputs.component.spec.ts
+++ b/src/app/components/pages/settings/outputs/outputs.component.spec.ts
@@ -1,31 +1,13 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
-import { NO_ERRORS_SCHEMA, Pipe, PipeTransform } from '@angular/core';
+import { NO_ERRORS_SCHEMA } from '@angular/core';
 import { Observable } from 'rxjs/Observable';
 import { ActivatedRoute } from '@angular/router';
 import { MatDialogModule } from '@angular/material';
-import { BehaviorSubject } from 'rxjs/BehaviorSubject';
 
 import { OutputsComponent } from './outputs.component';
 import { WalletService } from '../../../../services/wallet.service';
-import { BaseCoin } from '../../../../coins/basecoin';
 import { CoinService } from '../../../../services/coin.service';
-
-class MockWalletService {
-  outputsWithWallets() {
-    return Observable.of([]);
-  }
-}
-
-class MockCoinService {
-  currentCoin = new BehaviorSubject<BaseCoin>(null);
-}
-
-@Pipe({name: 'translate'})
-class MockTranslatePipe implements PipeTransform {
-  transform() {
-    return 'translated value';
-  }
-}
+import { MockTranslatePipe, MockWalletService, MockCoinService } from '../../../../utils/test-mocks';
 
 describe('OutputsComponent', () => {
   let component: OutputsComponent;

--- a/src/app/components/pages/settings/pending-transactions/pending-transactions.component.spec.ts
+++ b/src/app/components/pages/settings/pending-transactions/pending-transactions.component.spec.ts
@@ -1,56 +1,17 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
-import { NO_ERRORS_SCHEMA, Pipe, PipeTransform } from '@angular/core';
-import { Observable } from 'rxjs/Observable';
-import { BehaviorSubject } from 'rxjs/BehaviorSubject';
+import { NO_ERRORS_SCHEMA } from '@angular/core';
 
 import { PendingTransactionsComponent } from './pending-transactions.component';
 import { WalletService } from '../../../../services/wallet.service';
 import { NavBarService } from '../../../../services/nav-bar.service';
-import { Wallet } from '../../../../app.datatypes';
-import { BaseCoin } from '../../../../coins/basecoin';
 import { CoinService } from '../../../../services/coin.service';
-
-class MockWalletService {
-  get all(): Observable<Wallet[]> {
-    return Observable.of([]);
-  }
-
-  getAllPendingTransactions() {
-    return Observable.of([]);
-  }
-
-  getTransactionDetails() {
-    return Observable.of({});
-  }
-}
-
-class MockNavBarService {
-  activeComponent = new BehaviorSubject({});
-
-  showSwitch(leftText: any, rightText: any) {}
-
-  hideSwitch() {}
-
-  setActiveComponent() {}
-}
-
-class MockCoinService {
-  currentCoin = new BehaviorSubject<BaseCoin>(null);
-}
-
-@Pipe({name: 'translate'})
-class MockTranslatePipe implements PipeTransform {
-  transform() {
-    return 'translated value';
-  }
-}
-
-@Pipe({name: 'dateTime'})
-class MockDateTimePipe implements PipeTransform {
-  transform() {
-    return 'transformed value';
-  }
-}
+import {
+  MockTranslatePipe,
+  MockDateTimePipe,
+  MockNavBarService,
+  MockCoinService,
+  MockWalletService
+} from '../../../../utils/test-mocks';
 
 describe('PendingTransactionsComponent', () => {
   let component: PendingTransactionsComponent;

--- a/src/app/components/pages/wallets/change-name/change-name.component.spec.ts
+++ b/src/app/components/pages/wallets/change-name/change-name.component.spec.ts
@@ -1,20 +1,11 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
-import { NO_ERRORS_SCHEMA, Pipe, PipeTransform } from '@angular/core';
+import { NO_ERRORS_SCHEMA } from '@angular/core';
 import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material';
 import { FormBuilder } from '@angular/forms';
 
 import { ChangeNameComponent } from './change-name.component';
 import { WalletService } from '../../../../services/wallet.service';
-
-class MockWalletService {
-}
-
-@Pipe({name: 'translate'})
-class MockTranslatePipe implements PipeTransform {
-  transform() {
-    return 'translated value';
-  }
-}
+import { MockTranslatePipe, MockWalletService } from '../../../../utils/test-mocks';
 
 describe('ChangeNameComponent', () => {
   let component: ChangeNameComponent;

--- a/src/app/components/pages/wallets/create-wallet/create-wallet.component.spec.ts
+++ b/src/app/components/pages/wallets/create-wallet/create-wallet.component.spec.ts
@@ -1,27 +1,12 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
-import { NO_ERRORS_SCHEMA, Pipe, PipeTransform } from '@angular/core';
+import { NO_ERRORS_SCHEMA } from '@angular/core';
 import { FormBuilder } from '@angular/forms';
 import { MAT_DIALOG_DATA, MatDialogRef, MatSnackBarModule } from '@angular/material';
-import { BehaviorSubject } from 'rxjs/BehaviorSubject';
 
 import { CreateWalletComponent } from './create-wallet.component';
 import { WalletService } from '../../../../services/wallet.service';
 import { CoinService } from '../../../../services/coin.service';
-import { BaseCoin } from '../../../../coins/basecoin';
-
-class MockWalletService {
-}
-
-class MockCoinService {
-  currentCoin = new BehaviorSubject<BaseCoin>(null);
-}
-
-@Pipe({name: 'translate'})
-class MockTranslatePipe implements PipeTransform {
-  transform() {
-    return 'translated value';
-  }
-}
+import { MockTranslatePipe, MockWalletService, MockCoinService } from '../../../../utils/test-mocks';
 
 describe('CreateWalletComponent', () => {
   let component: CreateWalletComponent;

--- a/src/app/components/pages/wallets/unlock-wallet/unlock-wallet.component.spec.ts
+++ b/src/app/components/pages/wallets/unlock-wallet/unlock-wallet.component.spec.ts
@@ -1,20 +1,11 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
-import { NO_ERRORS_SCHEMA, Pipe, PipeTransform } from '@angular/core';
+import { NO_ERRORS_SCHEMA } from '@angular/core';
 import { MAT_DIALOG_DATA, MatDialogRef, MatSnackBar } from '@angular/material';
 import { FormBuilder } from '@angular/forms';
 
 import { UnlockWalletComponent } from './unlock-wallet.component';
 import { WalletService } from '../../../../services/wallet.service';
-
-class MockWalletService {
-}
-
-@Pipe({name: 'translate'})
-class MockTranslatePipe implements PipeTransform {
-  transform() {
-    return 'translated value';
-  }
-}
+import { MockTranslatePipe, MockWalletService } from '../../../../utils/test-mocks';
 
 describe('UnlockWalletComponent', () => {
   let component: UnlockWalletComponent;

--- a/src/app/components/pages/wallets/wallet-detail/wallet-detail.component.spec.ts
+++ b/src/app/components/pages/wallets/wallet-detail/wallet-detail.component.spec.ts
@@ -1,31 +1,14 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { MatDialog, MatSnackBar, MatMenuModule } from '@angular/material';
 import { RouterTestingModule } from '@angular/router/testing';
-import { NO_ERRORS_SCHEMA, Pipe, PipeTransform } from '@angular/core';
+import { NO_ERRORS_SCHEMA } from '@angular/core';
 import { TranslateService } from '@ngx-translate/core';
-import { Observable } from 'rxjs/Observable';
 
 import { WalletDetailComponent } from './wallet-detail.component';
 import { WalletService } from '../../../../services/wallet.service';
-
-@Pipe({name: 'translate'})
-class MockTranslatePipe implements PipeTransform {
-  transform() {
-    return 'translated value';
-  }
-}
-
-class MockWalletService {
-}
-
-class MockTranslateService {
-  get(key: string | Array<string>, interpolateParams?: Object): Observable<string | any> {
-    return Observable.of({});
-  }
-}
+import { MockTranslatePipe, MockWalletService, MockTranslateService } from '../../../../utils/test-mocks';
 
 describe('WalletDetailComponent', () => {
-
   let component: WalletDetailComponent;
   let fixture: ComponentFixture<WalletDetailComponent>;
 

--- a/src/app/components/pages/wallets/wallets.component.spec.ts
+++ b/src/app/components/pages/wallets/wallets.component.spec.ts
@@ -1,40 +1,11 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
-import { NO_ERRORS_SCHEMA, Pipe, PipeTransform } from '@angular/core';
+import { NO_ERRORS_SCHEMA } from '@angular/core';
 import { MatDialog } from '@angular/material';
-import { Observable } from 'rxjs/Observable';
-import { BehaviorSubject } from 'rxjs/BehaviorSubject';
 
 import { WalletsComponent } from './wallets.component';
 import { WalletService } from '../../../services/wallet.service';
-import { Wallet } from '../../../app.datatypes';
-import { BaseCoin } from '../../../coins/basecoin';
 import { CoinService } from '../../../services/coin.service';
-
-class MockWalletService {
-  get all(): Observable<Wallet[]> {
-    return Observable.of([]);
-  }
-}
-
-class MockCoinService {
-  currentCoin = new BehaviorSubject<BaseCoin>({
-    id: 1,
-    nodeUrl: 'nodeUrl',
-    nodeVersion: 'v1',
-    coinName: 'test coin',
-    coinSymbol: 'test',
-    hoursName: 'test',
-    cmcTickerId: 1,
-    coinExplorer: 'testUrl'
-  });
-}
-
-@Pipe({name: 'translate'})
-class MockTranslatePipe implements PipeTransform {
-  transform() {
-    return 'translated value';
-  }
-}
+import { MockTranslatePipe, MockCoinService, MockWalletService } from '../../../utils/test-mocks';
 
 describe('WalletsComponent', () => {
   let component: WalletsComponent;

--- a/src/app/directives/clipboard.directive.spec.ts
+++ b/src/app/directives/clipboard.directive.spec.ts
@@ -1,18 +1,9 @@
 import { TestBed, inject } from '@angular/core/testing';
-import { Component } from '@angular/core';
 import { By } from '@angular/platform-browser';
 
 import { ClipboardDirective } from './clipboard.directive';
 import { ClipboardService } from '../services/clipboard.service';
-
-@Component({
-  template: `<span clipboard="test data"></span>`
-})
-class TestComponent {
-}
-
-class MockClipboardService {
-}
+import { MockClipboardService, TestComponent } from '../utils/test-mocks';
 
 describe('Directive: Clipboard', () => {
   beforeEach(() => {

--- a/src/app/directives/number-field.directive.spec.ts
+++ b/src/app/directives/number-field.directive.spec.ts
@@ -1,14 +1,8 @@
-import { TestBed, inject } from '@angular/core/testing';
-import { Component } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 
 import { NumberFieldDirective } from './number-field.directive';
-
-@Component({
-  template: `<input type="text" appNumberField>`
-})
-class TestComponent {
-}
+import { TestComponent } from '../utils/test-mocks';
 
 describe('Directive: NumberField', () => {
   beforeEach(() => {

--- a/src/app/services/api.service.spec.ts
+++ b/src/app/services/api.service.spec.ts
@@ -1,16 +1,10 @@
 import { TestBed, inject } from '@angular/core/testing';
 import { MockBackend } from '@angular/http/testing';
 import { HttpModule, XHRBackend } from '@angular/http';
-import { Observable } from 'rxjs/Observable';
-
-import { ApiService } from './api.service';
 import { TranslateService } from '@ngx-translate/core';
 
-class MockTranslateService {
-  get(key: string | Array<string>, interpolateParams?: Object): Observable<string | any> {
-    return Observable.of({});
-  }
-}
+import { ApiService } from './api.service';
+import { MockTranslateService } from '../utils/test-mocks';
 
 describe('ApiService', () => {
   let service: ApiService;

--- a/src/app/services/blockchain.service.spec.ts
+++ b/src/app/services/blockchain.service.spec.ts
@@ -1,22 +1,9 @@
 import { TestBed, inject } from '@angular/core/testing';
-import { Observable } from 'rxjs/Observable';
 
 import { BlockchainService } from './blockchain.service';
 import { ApiService } from './api.service';
 import { WalletService } from './wallet.service';
-
-class MockApiService {
-  get(url: string) {
-    if (url === 'network/connections') {
-      return Observable.of({ connections: [] });
-    } else {
-      return Observable.of({});
-    }
-  }
-}
-
-class MockWalletService {
-}
+import { MockApiService, MockWalletService } from '../utils/test-mocks';
 
 describe('BlockchainService', () => {
   let service: BlockchainService;

--- a/src/app/services/price.service.spec.ts
+++ b/src/app/services/price.service.spec.ts
@@ -1,14 +1,10 @@
 import { TestBed } from '@angular/core/testing';
 import { MockBackend } from '@angular/http/testing';
 import { HttpModule, XHRBackend } from '@angular/http';
-import { BehaviorSubject } from 'rxjs/BehaviorSubject';
 
 import { PriceService } from './price.service';
 import { CoinService } from './coin.service';
-
-class MockCoinService {
-  currentCoin = new BehaviorSubject({ cmcTickerId: 1 });
-}
+import { MockCoinService } from '../utils/test-mocks';
 
 describe('PriceService', () => {
   let priceService: PriceService;

--- a/src/app/services/wallet.service.cipher.spec.ts
+++ b/src/app/services/wallet.service.cipher.spec.ts
@@ -1,17 +1,13 @@
 import { TestBed, fakeAsync } from '@angular/core/testing';
 import { Observable } from 'rxjs/Observable';
 import { TranslateService } from '@ngx-translate/core';
-import { BehaviorSubject } from 'rxjs/BehaviorSubject';
 
 import { WalletService } from './wallet.service';
 import { ApiService } from './api.service';
 import { CipherProvider } from './cipher.provider';
 import { Wallet, Address, TransactionOutput, TransactionInput, Output, Balance } from '../app.datatypes';
 import { CoinService } from './coin.service';
-
-class MockCoinService {
-  currentCoin = new BehaviorSubject({ cmcTickerId: 1 });
-}
+import { MockCoinService } from '../utils/test-mocks';
 
 describe('WalletService with cipher:', () => {
   let store = {};

--- a/src/app/services/wallet.service.spec.ts
+++ b/src/app/services/wallet.service.spec.ts
@@ -6,13 +6,18 @@ import { TranslateService } from '@ngx-translate/core';
 import { WalletService } from './wallet.service';
 import { ApiService } from './api.service';
 import { CipherProvider } from './cipher.provider';
-import { Wallet, Address, NormalTransaction, TransactionOutput, TransactionInput, Output, Balance, GetOutputsRequestOutput } from '../app.datatypes';
 import { CoinService } from './coin.service';
 import { EventEmitter } from '@angular/core';
-
-class MockCoinService {
-  currentCoin = new BehaviorSubject({ cmcTickerId: 1, id: 1, hoursName: 'SKY Hours' });
-}
+import { MockCoinService } from '../utils/test-mocks';
+import {
+  Wallet,
+  Address,
+  NormalTransaction,
+  TransactionOutput,
+  TransactionInput,
+  Output,
+  Balance,
+  GetOutputsRequestOutput } from '../app.datatypes';
 
 describe('WalletService', () => {
   let store = {};
@@ -337,7 +342,7 @@ describe('WalletService', () => {
         });
     }));
 
-    it('should be rejected for not enough Sky Hours', () => {
+    it('should be rejected for not enough hours', () => {
       const address = 'address';
       const amount = 2;
 
@@ -367,7 +372,7 @@ describe('WalletService', () => {
       walletService.createTransaction(wallet, address, amount)
         .subscribe(
           () => fail('should be rejected'),
-          (error) => expect(error.message).toBe('Not enough available SKY Hours to perform transaction!')
+          (error) => expect(error.message).toBe('Not enough available Test Hours to perform transaction!')
         );
     });
   });

--- a/src/app/utils/test-mocks.ts
+++ b/src/app/utils/test-mocks.ts
@@ -1,0 +1,178 @@
+import { Pipe, PipeTransform, Component } from '@angular/core';
+import { BehaviorSubject } from 'rxjs/BehaviorSubject';
+import { Observable } from 'rxjs/Observable';
+import { Subject } from 'rxjs/Subject';
+import { ReplaySubject } from 'rxjs/ReplaySubject';
+
+import { BaseCoin } from '../coins/basecoin';
+import { TotalBalance, Wallet } from '../app.datatypes';
+
+// -- Components
+@Component({
+  template: `
+    <span clipboard="test data"></span>
+    <input type="text" appNumberField>`
+})
+export class TestComponent {
+}
+
+// --- Pipes
+@Pipe({name: 'translate'})
+export class MockTranslatePipe implements PipeTransform {
+  transform() {
+    return 'translated value';
+  }
+}
+
+@Pipe({name: 'tellerStatus'})
+export class MockTellerStatusPipe implements PipeTransform {
+  transform() {
+    return 'transformed value';
+  }
+}
+
+@Pipe({ name: 'dateTime' })
+export class MockDateTimePipe implements PipeTransform {
+  transform() {
+    return 'transformed value';
+  }
+}
+
+@Pipe({name: 'dateFromNow'})
+export class MockDateFromNowPipe implements PipeTransform {
+  transform() {
+    return 'transformed value';
+  }
+}
+
+// --- Services
+export class MockFeatureService {
+  getFeatureToggleData(): any {
+    return {};
+  }
+}
+
+export class MockNavBarService {
+  activeComponent = new BehaviorSubject({});
+
+  showSwitch(leftText: any, rightText: any) {}
+
+  hideSwitch() {}
+
+  setActiveComponent() {}
+}
+
+export class MockPurchaseService {
+  all(): Observable<any[]> {
+    return Observable.of([]);
+  }
+}
+
+export class MockCoinService {
+  currentCoin = new BehaviorSubject<BaseCoin>({
+    id: 1,
+    cmcTickerId: 1,
+    nodeUrl: 'nodeUrl',
+    nodeVersion: 'v1',
+    coinName: 'test coin',
+    coinSymbol: 'test',
+    hoursName: 'Test Hours',
+    coinExplorer: 'testUrl'
+  });
+}
+
+export class MockWalletService {
+  hasPendingTransactions: Subject<boolean> = new ReplaySubject<boolean>();
+  isWalletsExist: Observable<boolean> = Observable.of();
+
+  get timeSinceLastBalancesUpdate(): Observable<void> {
+    return Observable.of();
+  }
+
+  get totalBalance(): BehaviorSubject<TotalBalance> {
+    return new BehaviorSubject<TotalBalance>(null);
+  }
+
+  get addresses(): Observable<any[]> {
+    return Observable.of([]);
+  }
+
+  get all(): Observable<Wallet[]> {
+    return Observable.of([]);
+  }
+
+  sum() {
+  }
+
+  transactions(): Observable<any[]> {
+    return Observable.of([]);
+  }
+
+  generateSeed(entropy) {
+    return Observable.of('');
+  }
+
+  outputsWithWallets() {
+    return Observable.of([]);
+  }
+
+  getAllPendingTransactions() {
+    return Observable.of([]);
+  }
+
+  getTransactionDetails() {
+    return Observable.of({});
+  }
+}
+
+export class MockPriceService {
+  price: Subject<number> = new BehaviorSubject<number>(null);
+}
+
+export class MockBlockchainService {
+  get progress() {
+    return Observable.of();
+  }
+
+  lastBlock(): Observable<any> {
+    return Observable.of({});
+  }
+
+  coinSupply(): Observable<any> {
+    return Observable.of({});
+  }
+}
+
+export class MockMatSnackBar {
+  dismiss() {
+  }
+}
+
+export class MockTranslateService {
+  get(key: string | Array<string>, interpolateParams?: Object): Observable<string | any> {
+    return Observable.of({});
+  }
+
+  addLangs(langs: Array<string>): void {
+  }
+
+  setDefaultLang(lang: string): void {
+  }
+
+  use(lang: string): Observable<any> {
+    return Observable.of({});
+  }
+}
+
+export class MockApiService {
+  get(url: string) {
+    if (url === 'network/connections') {
+      return Observable.of({ connections: [] });
+    } else {
+      return Observable.of({});
+    }
+  }
+}
+
+export class MockClipboardService {
+}

--- a/src/tsconfig.app.json
+++ b/src/tsconfig.app.json
@@ -8,6 +8,7 @@
   },
   "exclude": [
     "test.ts",
-    "**/*.spec.ts"
+    "**/*.spec.ts",
+    "./app/utils/test-mocks.ts"
   ]
 }

--- a/src/tsconfig.spec.json
+++ b/src/tsconfig.spec.json
@@ -15,6 +15,7 @@
   ],
   "include": [
     "**/*.spec.ts",
-    "**/*.d.ts"
+    "**/*.d.ts",
+    "./app/utils/test-mocks.ts"
   ]
 }


### PR DESCRIPTION
Fixes #346 

Changes:
- all mock classes (services, pipes, components) were moved to the separate file and reused in unit-tests.
