### PR TITLE
#367: Save the selected coin in every tab

### DIFF
--- a/src/app/services/coin.service.ts
+++ b/src/app/services/coin.service.ts
@@ -15,6 +15,7 @@ export class CoinService {
   constructor() {
     this.loadAvailableCoins();
     this.loadCurrentCoin();
+    this.saveCoin(this.currentCoin.getValue().id);
   }
 
   changeCoin(coin: BaseCoin) {
@@ -23,15 +24,15 @@ export class CoinService {
   }
 
   private loadCurrentCoin() {
-    const storedCoinId = localStorage.getItem(this.storageKey);
+    const storedCoinId = sessionStorage.getItem(this.storageKey) || localStorage.getItem(this.storageKey);
     const coinId = storedCoinId ? +storedCoinId : defaultCoinId;
-
     const coin = this.coins.find((c: BaseCoin) => c.id === coinId);
     this.currentCoin.next(coin);
   }
 
   private saveCoin(coinId: number) {
     localStorage.setItem(this.storageKey, coinId.toString());
+    sessionStorage.setItem(this.storageKey, coinId.toString());
   }
 
   private loadAvailableCoins() {

--- a/src/app/services/coin.service.ts
+++ b/src/app/services/coin.service.ts
@@ -15,7 +15,7 @@ export class CoinService {
   constructor() {
     this.loadAvailableCoins();
     this.loadCurrentCoin();
-    this.saveCoin(this.currentCoin.getValue().id);
+    sessionStorage.setItem(this.storageKey, this.currentCoin.getValue().id.toString());
   }
 
   changeCoin(coin: BaseCoin) {


### PR DESCRIPTION
Fixes #367 

Changes:
- currently selected coin is being stored in the sessionStorage as well in order to be able to work with different coins in the separate tabs
