### PR TITLE
#397: Normalize confirmation modal styles

### DIFF
--- a/src/app/components/layout/confirmation/confirmation.component.scss
+++ b/src/app/components/layout/confirmation/confirmation.component.scss
@@ -1,7 +1,8 @@
 .-body {
-  padding: 30px 0;
-  font-size: 13px;
-  text-align: center;
+  line-height: 20px;
+  font-size: 12px;
+  color: #1E2227;
+  opacity: 0.8;
 }
 
 .-buttons {
@@ -10,7 +11,7 @@
 
 .-check-container{
   text-align: center;
-  margin: 10px;
+  margin-top: 50px;
 }
 
 .-disclaimer-check-text {
@@ -45,4 +46,8 @@
     border-radius: 6px;
     border-color: transparent;
   }
+}
+
+app-button ::ng-deep button {
+  margin-top: 28px;
 }

--- a/src/app/components/pages/wallets/wallet-detail/wallet-detail.component.ts
+++ b/src/app/components/pages/wallets/wallet-detail/wallet-detail.component.ts
@@ -95,8 +95,8 @@ export class WalletDetailComponent {
   }
 
   private showDeleteConfirmation(confirmationData: ConfirmationData) {
-    const dialogRef = this.dialog.open(ConfirmationComponent, {
-      width: '500px',
+    const dialogRef = this.dialog.open(ConfirmationComponent, <MatDialogConfig>{
+      width: '450px',
       data: confirmationData
     });
 


### PR DESCRIPTION
Fixes #397

Changes:
- makes wallet delete confirmation modal styles same as onboarding's
