### PR TITLE
Code cleaning - ApiService

### DIFF
--- a/e2e/onboarding-create.po.ts
+++ b/e2e/onboarding-create.po.ts
@@ -52,6 +52,7 @@ export class OnboardingCreatePage {
   }
 
   closeSafeguard() {
+    browser.sleep(250);
     element(by.css('img.btn-close')).click();
     return this.getSafeguardIsShow();
   }

--- a/e2e/transactions.po.ts
+++ b/e2e/transactions.po.ts
@@ -30,6 +30,7 @@ export class TransactionsPage {
   }
 
   hideTransactionModal() {
+    browser.sleep(250);
     return element(by.css('.-header img')).click().then(() => {
       return this.getTransactionDetailIsShow();
     });

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -1,7 +1,6 @@
 import { HttpClientModule } from '@angular/common/http';
 import { NgModule } from '@angular/core';
 import { ReactiveFormsModule, FormsModule } from '@angular/forms';
-import { HttpModule } from '@angular/http';
 import { MatInputModule } from '@angular/material';
 import { MatButtonModule } from '@angular/material/button';
 import { MatCardModule } from '@angular/material/card';
@@ -128,7 +127,6 @@ import { LanguageService } from './services/language.service';
   ],
   imports: [
     BrowserModule,
-    HttpModule,
     HttpClientModule,
     MatButtonModule,
     MatCardModule,

--- a/src/app/services/api.service.spec.ts
+++ b/src/app/services/api.service.spec.ts
@@ -1,7 +1,8 @@
 import { TestBed, inject } from '@angular/core/testing';
 import { MockBackend } from '@angular/http/testing';
-import { HttpModule, XHRBackend } from '@angular/http';
+import { XHRBackend } from '@angular/http';
 import { TranslateService } from '@ngx-translate/core';
+import { HttpClientModule } from '@angular/common/http';
 
 import { ApiService } from './api.service';
 import { MockTranslateService, MockCoinService } from '../utils/test-mocks';
@@ -13,7 +14,7 @@ describe('ApiService', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [ HttpModule ],
+      imports: [ HttpClientModule ],
       providers: [
         ApiService,
         { provide: XHRBackend, useClass: MockBackend },

--- a/src/app/services/api.service.ts
+++ b/src/app/services/api.service.ts
@@ -43,7 +43,6 @@ export class ApiService {
 
   get(url, params = null, options = {}): Observable<any> {
     return this.http.get(this.getUrl(url), this.getRequestOptions(options, params))
-      .map((res: any) => res)
       .catch((error: any) => this.getErrorMessage(error));
   }
 
@@ -51,7 +50,6 @@ export class ApiService {
     return this.getCsrf().first().flatMap(csrf => {
       options.csrf = csrf;
       return this.http.post(this.getUrl(url), body, this.getRequestOptions(options))
-        .map((res: any) => res)
         .catch((error: any) => this.getErrorMessage(error));
     });
   }

--- a/src/app/services/api.service.ts
+++ b/src/app/services/api.service.ts
@@ -10,6 +10,7 @@ import { TranslateService } from '@ngx-translate/core';
 import { GetOutputsRequest, Output } from '../app.datatypes';
 import { CoinService } from './coin.service';
 import { BaseCoin } from '../coins/basecoin';
+import { parseResponseMessage } from '../utils/errors';
 
 @Injectable()
 export class ApiService {
@@ -90,13 +91,11 @@ export class ApiService {
     return this.get('csrf').map(response => response.csrf_token);
   }
 
-  private getErrorMessage(error: any): Observable<any> {
-    if (error) {
-      if (error.error) {
-        return Observable.throw(new Error(error.error.trim()));
-      } else {
-        return Observable.throw(error);
-      }
+  private getErrorMessage(error: any): Observable<string> {
+    if (error.error) {
+      return Observable.throw(new Error(parseResponseMessage(error.error.trim())));
+    } if (error.message) {
+      return Observable.throw(new Error(parseResponseMessage(error.message.trim())));
     }
 
     this.translate.get('service.api.server-error')

--- a/src/app/services/api.service.ts
+++ b/src/app/services/api.service.ts
@@ -98,7 +98,7 @@ export class ApiService {
       return Observable.throw(new Error(parseResponseMessage(error.message.trim())));
     }
 
-    this.translate.get('service.api.server-error')
+    return this.translate.get('service.api.server-error')
       .flatMap(message => Observable.throw(new Error(message)));
   }
 }

--- a/src/app/services/price.service.spec.ts
+++ b/src/app/services/price.service.spec.ts
@@ -1,6 +1,7 @@
 import { TestBed } from '@angular/core/testing';
 import { MockBackend } from '@angular/http/testing';
-import { HttpModule, XHRBackend } from '@angular/http';
+import { XHRBackend } from '@angular/http';
+import { HttpClientModule } from '@angular/common/http';
 
 import { PriceService } from './price.service';
 import { CoinService } from './coin.service';
@@ -11,7 +12,7 @@ describe('PriceService', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [ HttpModule ],
+      imports: [ HttpClientModule ],
       providers: [
         PriceService,
         { provide: XHRBackend, useClass: MockBackend },

--- a/src/app/services/price.service.ts
+++ b/src/app/services/price.service.ts
@@ -1,5 +1,5 @@
 import { Injectable, NgZone } from '@angular/core';
-import { Http } from '@angular/http';
+import { HttpClient } from '@angular/common/http';
 import { BehaviorSubject } from 'rxjs/BehaviorSubject';
 import { Subject } from 'rxjs/Subject';
 import { Observable } from 'rxjs/Observable';
@@ -15,7 +15,7 @@ export class PriceService {
   private readonly updatePeriod = 10 * 60 * 1000;
 
   constructor(
-    private http: Http,
+    private http: HttpClient,
     private ngZone: NgZone,
     private coinService: CoinService
   ) {
@@ -36,7 +36,7 @@ export class PriceService {
     }
 
     this.http.get(`https://api.coinmarketcap.com/v2/ticker/${this.cmcTickerId}/`)
-      .map(response => response.json())
-      .subscribe(response => this.price.next(response.data.quotes.USD.price));
+      .map(response => response)
+      .subscribe((response: any) => this.price.next(response.data.quotes.USD.price));
   }
 }

--- a/src/app/services/price.service.ts
+++ b/src/app/services/price.service.ts
@@ -36,7 +36,6 @@ export class PriceService {
     }
 
     this.http.get(`https://api.coinmarketcap.com/v2/ticker/${this.cmcTickerId}/`)
-      .map(response => response)
       .subscribe((response: any) => this.price.next(response.data.quotes.USD.price));
   }
 }


### PR DESCRIPTION
Changes in the first commit:
- `Http` has been replaced with `HttpClient`, as `Http` has ben deprecated. The change was also made in `PriceService` to completely delete `Http`.
- The querystrings are created using `HttpParams`, instead of manually adding the text to the URL. 
- The type was added to various parameters and functions that did not have it.
- The function for processing the errors now returns the `error.error` text by default, because before it returned the complete error and the text of `error.message` was being used by default by the components, which was not adequate. For example, this error was being displayed:
![lg](https://user-images.githubusercontent.com/34079003/42339793-07d7f5f0-805c-11e8-9a0e-80863270bede.png)
with the change now this error is shown:
![imagen](https://user-images.githubusercontent.com/34079003/42339804-11521ba6-805c-11e8-9082-effae52a118d.png)
- Small modifications were made to the e2e tests because they were failing locally.

In general, this pr was made while cleaning the `ApiService` code. There are still some methods that should not be inside `ApiService`, but they will be moved when cleaning the code of the services in which those methods should be.