### PR TITLE
Scan the addresses when loading a wallet

### DIFF
--- a/e2e/onboarding-create.e2e-spec.ts
+++ b/e2e/onboarding-create.e2e-spec.ts
@@ -7,6 +7,7 @@ describe('Onboarding Create', () => {
 
   beforeAll(() => {
     browser.get('/');
+    browser.waitForAngularEnabled(false);
 
     page = new OnboardingCreatePage();
     page.navigateTo();

--- a/e2e/onboarding-create.po.ts
+++ b/e2e/onboarding-create.po.ts
@@ -159,6 +159,7 @@ export class OnboardingCreatePage {
 
     return btnLoad.click().then(() => {
       this.waitUntilWalletIsCreated();
+      browser.sleep(5000);
 
       return browser.executeScript('return window.localStorage.getItem("wallets");')
         .then((data: string) => {
@@ -236,6 +237,6 @@ export class OnboardingCreatePage {
   }
 
   private waitUntilWalletIsCreated() {
-    browser.wait(ExpectedConditions.invisibilityOf(element(by.buttonText('Create'))), 20000);
+    browser.wait(ExpectedConditions.invisibilityOf(element(by.buttonText('Create'))), 60000);
   }
 }

--- a/e2e/send_sky.e2e-spec.ts
+++ b/e2e/send_sky.e2e-spec.ts
@@ -9,6 +9,7 @@ describe('Send Sky', () => {
 
   beforeAll(() => {
     browser.get('/');
+    browser.waitForAngularEnabled(false);
     browser.executeScript(
       `window.localStorage.setItem(\'wallets\',
         JSON.stringify([{"label":"Test wallet","addresses":

--- a/e2e/transactions.e2e-spec.ts
+++ b/e2e/transactions.e2e-spec.ts
@@ -7,6 +7,7 @@ describe('Transactions', () => {
 
   beforeAll(() => {
     browser.get('/');
+    browser.waitForAngularEnabled(false);
     browser.executeScript(
       `window.localStorage.setItem(\'wallets\',
         JSON.stringify([{"label":"Test wallet","addresses":

--- a/e2e/wallets.e2e-spec.ts
+++ b/e2e/wallets.e2e-spec.ts
@@ -7,6 +7,7 @@ describe('Wallets', () => {
 
   beforeAll(() => {
     browser.get('/');
+    browser.waitForAngularEnabled(false);
     browser.executeScript(
       `window.localStorage.setItem(\'wallets\',
       JSON.stringify([{"label":"Test wallet","addresses":

--- a/e2e/wallets.po.ts
+++ b/e2e/wallets.po.ts
@@ -100,7 +100,7 @@ export class WalletsPage {
   }
 
   waitUntilWalletIsCreated() {
-    browser.wait(ExpectedConditions.invisibilityOf(element(by.css('app-create-wallet'))), 50000);
+    browser.wait(ExpectedConditions.invisibilityOf(element(by.css('app-create-wallet'))), 60000);
   }
 
   loadExistingWallet() {
@@ -159,7 +159,7 @@ export class WalletsPage {
         return lastRecord.element(by.css('.address-column')).getText().then((address) => {
           return address === 'bSp3JvfGiHzumCpdaWT7tGRtejwhLDd2zv';
         });
-      }, 5000);
+      }, 10000);
     });
   }
 
@@ -234,6 +234,7 @@ export class WalletsPage {
 
     return element(by.buttonText('Unlock')).click().then(() => {
       browser.wait(ExpectedConditions.invisibilityOf(element(by.css('app-unlock-wallet'))), 20000);
+      browser.sleep(5000);
       return (element(by.css('app-unlock-wallet')).isPresent()).then((result) => {
         return !result;
       });

--- a/protractor.conf.js
+++ b/protractor.conf.js
@@ -16,7 +16,7 @@ exports.config = {
   framework: 'jasmine',
   jasmineNodeOpts: {
     showColors: true,
-    defaultTimeoutInterval: 30000,
+    defaultTimeoutInterval: 60000,
     print: function() {}
   },
   beforeLaunch: function() {

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -79,6 +79,7 @@ import { BalanceService } from './services/wallet/balance.service';
 import { HistoryService } from './services/wallet/history.service';
 import { SpendingService } from './services/wallet/spending.service';
 import { CreateWalletFormComponent } from './components/pages/wallets/create-wallet/create-wallet-form/create-wallet-form.component';
+import { ScanAddressesComponent } from './components/pages/wallets/scan-addresses/scan-addresses.component';
 
 @NgModule({
   declarations: [
@@ -119,7 +120,8 @@ import { CreateWalletFormComponent } from './components/pages/wallets/create-wal
     CoinButtonComponent,
     SelectCoinOverlayComponent,
     SelectLanguageComponent,
-    CreateWalletFormComponent
+    CreateWalletFormComponent,
+    ScanAddressesComponent
   ],
   entryComponents: [
     AddDepositAddressComponent,
@@ -130,7 +132,8 @@ import { CreateWalletFormComponent } from './components/pages/wallets/create-wal
     TransactionDetailComponent,
     ConfirmationComponent,
     SelectCoinOverlayComponent,
-    SelectLanguageComponent
+    SelectLanguageComponent,
+    ScanAddressesComponent
   ],
   imports: [
     BrowserModule,

--- a/src/app/components/pages/onboarding/onboarding-create-wallet/onboarding-create-wallet.component.spec.ts
+++ b/src/app/components/pages/onboarding/onboarding-create-wallet/onboarding-create-wallet.component.spec.ts
@@ -4,14 +4,15 @@ import { MatDialogModule, MatSnackBarModule } from '@angular/material';
 import { RouterTestingModule } from '@angular/router/testing';
 import { FormBuilder } from '@angular/forms';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
-import { BrowserDynamicTestingModule } from '@angular/platform-browser-dynamic/testing';
+import { TranslateService } from '@ngx-translate/core';
 
 import { OnboardingCreateWalletComponent } from './onboarding-create-wallet.component';
 import { WalletService } from '../../../../services/wallet/wallet.service';
 import { CoinService } from '../../../../services/coin.service';
-import { MockTranslatePipe, MockWalletService, MockCoinService, MockLanguageService } from '../../../../utils/test-mocks';
+import { MockTranslatePipe, MockWalletService, MockCoinService, MockLanguageService, MockBlockchainService } from '../../../../utils/test-mocks';
 import { LanguageService } from '../../../../services/language.service';
 import { CreateWalletFormComponent } from '../../wallets/create-wallet/create-wallet-form/create-wallet-form.component';
+import { BlockchainService } from '../../../../services/blockchain.service';
 
 describe('OnboardingCreateWalletComponent', () => {
   let component: OnboardingCreateWalletComponent;
@@ -34,7 +35,12 @@ describe('OnboardingCreateWalletComponent', () => {
         FormBuilder,
         { provide: WalletService, useClass: MockWalletService },
         { provide: CoinService, useClass: MockCoinService },
-        { provide: LanguageService, useClass: MockLanguageService }
+        { provide: LanguageService, useClass: MockLanguageService },
+        { provide: BlockchainService, useClass: MockBlockchainService },
+        {
+          provide: TranslateService,
+          useValue: jasmine.createSpyObj('TranslateService', ['instant'])
+        },
       ],
       schemas: [ NO_ERRORS_SCHEMA ]
     });

--- a/src/app/components/pages/wallets/create-wallet/create-wallet.component.spec.ts
+++ b/src/app/components/pages/wallets/create-wallet/create-wallet.component.spec.ts
@@ -1,11 +1,13 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { NO_ERRORS_SCHEMA } from '@angular/core';
-import { MAT_DIALOG_DATA, MatDialogRef, MatSnackBarModule } from '@angular/material';
+import { MAT_DIALOG_DATA, MatDialogRef, MatSnackBarModule, MatDialogModule } from '@angular/material';
+import { TranslateService } from '@ngx-translate/core';
 
 import { CreateWalletComponent } from './create-wallet.component';
 import { WalletService } from '../../../../services/wallet/wallet.service';
 import { CoinService } from '../../../../services/coin.service';
-import { MockTranslatePipe, MockWalletService, MockCoinService } from '../../../../utils/test-mocks';
+import { MockTranslatePipe, MockWalletService, MockCoinService, MockBlockchainService } from '../../../../utils/test-mocks';
+import { BlockchainService } from '../../../../services/blockchain.service';
 
 describe('CreateWalletComponent', () => {
   let component: CreateWalletComponent;
@@ -14,13 +16,18 @@ describe('CreateWalletComponent', () => {
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       declarations: [ CreateWalletComponent, MockTranslatePipe ],
-      imports: [ MatSnackBarModule ],
+      imports: [ MatSnackBarModule, MatDialogModule ],
       schemas: [ NO_ERRORS_SCHEMA ],
       providers: [
         { provide: MAT_DIALOG_DATA, useValue: {} },
         { provide: WalletService, useClass: MockWalletService },
         { provide: MatDialogRef, useValue: {} },
-        { provide: CoinService, useClass: MockCoinService }
+        { provide: CoinService, useClass: MockCoinService },
+        { provide: BlockchainService, useClass: MockBlockchainService },
+        {
+          provide: TranslateService,
+          useValue: jasmine.createSpyObj('TranslateService', ['instant'])
+        },
       ]
     })
     .compileComponents();

--- a/src/app/components/pages/wallets/scan-addresses/scan-addresses.component.html
+++ b/src/app/components/pages/wallets/scan-addresses/scan-addresses.component.html
@@ -1,0 +1,10 @@
+<app-modal class="modal" [headline]="'wallet.scan.title' | translate"
+           [dialog]="dialogRef"
+           [disableDismiss]="true"
+           [loadingProgress]="progress.progress">
+
+  <div class="-body">
+    {{ 'wallet.scan.message' | translate }} {{ progress.addressesFound }}
+  </div>
+  
+</app-modal>

--- a/src/app/components/pages/wallets/scan-addresses/scan-addresses.component.spec.ts
+++ b/src/app/components/pages/wallets/scan-addresses/scan-addresses.component.spec.ts
@@ -1,0 +1,37 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { NO_ERRORS_SCHEMA } from '@angular/core';
+import { MAT_DIALOG_DATA, MatDialogRef, MatSnackBar } from '@angular/material';
+import { FormBuilder } from '@angular/forms';
+
+import { ScanAddressesComponent } from './scan-addresses.component';
+import { WalletService } from '../../../../services/wallet/wallet.service';
+import { MockTranslatePipe, MockWalletService } from '../../../../utils/test-mocks';
+
+describe('ScanAddressesComponent', () => {
+  let component: ScanAddressesComponent;
+  let fixture: ComponentFixture<ScanAddressesComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ ScanAddressesComponent, MockTranslatePipe ],
+      schemas: [ NO_ERRORS_SCHEMA ],
+      providers: [
+        FormBuilder,
+        { provide: WalletService, useClass: MockWalletService },
+        { provide: MatDialogRef, useValue: {} },
+        { provide: MAT_DIALOG_DATA, useValue: {} },
+      ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(ScanAddressesComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should be created', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/components/pages/wallets/scan-addresses/scan-addresses.component.ts
+++ b/src/app/components/pages/wallets/scan-addresses/scan-addresses.component.ts
@@ -1,0 +1,49 @@
+import { Component, EventEmitter, Inject, OnInit, Output, ViewChild, OnDestroy } from '@angular/core';
+import { FormBuilder, FormGroup, Validators } from '@angular/forms';
+import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
+import { MatSnackBar, MatSnackBarConfig } from '@angular/material/snack-bar';
+import { Subscription } from 'rxjs/Subscription';
+
+import { Wallet } from '../../../../app.datatypes';
+import { WalletService, ScanProgressData } from '../../../../services/wallet/wallet.service';
+
+@Component({
+  selector: 'app-scan-addresses',
+  templateUrl: './scan-addresses.component.html',
+  styleUrls: ['./scan-addresses.component.scss'],
+})
+export class ScanAddressesComponent implements OnInit, OnDestroy {
+  progress = new ScanProgressData();
+
+  private subscription: Subscription;
+
+  constructor(
+    @Inject(MAT_DIALOG_DATA) private data: Wallet,
+    public dialogRef: MatDialogRef<ScanAddressesComponent>,
+    private walletService: WalletService
+  ) {}
+
+  ngOnInit() {
+    this.scan();
+  }
+
+  ngOnDestroy() {
+    this.subscription.unsubscribe();
+  }
+
+  closePopup(result = null) {
+    this.dialogRef.close(result);
+  }
+
+  scan() {
+    const onProgressChanged = new EventEmitter<ScanProgressData>();
+    this.subscription = onProgressChanged.subscribe((progress: ScanProgressData) => this.progress = progress);
+
+    this.subscription.add(this.walletService.scanAddresses(this.data, onProgressChanged)
+      .subscribe(
+        () => this.closePopup(null),
+        (error: Error) => this.closePopup(error)
+      )
+    );
+  }
+}

--- a/src/app/services/api.service.ts
+++ b/src/app/services/api.service.ts
@@ -71,7 +71,7 @@ export class ApiService {
   }
 
   private getErrorMessage(error: any): Observable<string> {
-    if (error.error) {
+    if (error.error && typeof error.error === 'string') {
       return Observable.throw(new Error(parseResponseMessage(error.error.trim())));
     } if (error.message) {
       return Observable.throw(new Error(parseResponseMessage(error.message.trim())));

--- a/src/app/services/wallet/wallet.service.spec.ts
+++ b/src/app/services/wallet/wallet.service.spec.ts
@@ -9,6 +9,7 @@ import { CipherProvider } from '../cipher.provider';
 import { CoinService } from '../coin.service';
 import { EventEmitter } from '@angular/core';
 import { MockCoinService } from '../../utils/test-mocks';
+import { ApiService } from '../api.service';
 import {
   Wallet,
   Address } from '../../app.datatypes';
@@ -33,6 +34,12 @@ describe('WalletService', () => {
         {
           provide: TranslateService,
           useValue: jasmine.createSpyObj('TranslateService', ['instant'])
+        },
+        {
+          provide: ApiService,
+          useValue: jasmine.createSpyObj('ApiService', {
+            'get': Observable.of([])
+          })
         },
         { provide: CoinService, useClass: MockCoinService }
       ]

--- a/src/app/utils/test-mocks.ts
+++ b/src/app/utils/test-mocks.ts
@@ -91,6 +91,10 @@ export class MockWalletService {
   get currentWallets(): Observable<Wallet[]> {
     return Observable.of([]);
   }
+
+  scanAddresses(wallet, onProgressChanged): Observable<void> {
+    return Observable.of();
+  }
 }
 
 export class MockHistoryService {

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -157,6 +157,13 @@
       "unconventional-seed-check": "Continue with the unconventional seed."
     },
 
+    "scan": {
+      "connection-error": "It is not possible to connect to the server. Please try again later.",
+      "unsynchronized-node-error": "It is not possible to restore the addresses because the server is not synchronized. Please try again later.",
+      "title": "Restoring addresses",
+      "message": "Restored until now:"
+    },
+
     "unlock": {
       "unlock-title": "Unlock Wallet",
       "seed": "Seed",
@@ -299,7 +306,8 @@
       "wallet-exists": "A wallet already exists with this seed",
       "not-enough-hours1": "Not enough available",
       "not-enough-hours2": "to perform transaction!",
-      "wrong-seed": "Wrong seed"
+      "wrong-seed": "Wrong seed",
+      "invalid-wallet": "Invalid wallet"
     }
   }
 }

--- a/src/assets/i18n/es.json
+++ b/src/assets/i18n/es.json
@@ -104,7 +104,7 @@
     "confirm": {
       "title": "¡Resguarde su semilla!",
       "desc": "Queremos asegurarnos de que ha anotado su semilla y la ha almacenado en un lugar seguro. ¡Si olvida su semilla, NO podrá recuperar su billetera!",
-      "checkbox": "Está segura, lo aseguro.",
+      "checkbox": "Está segura, lo garantizo.",
       "button": "Continuar"
     }
   },
@@ -155,6 +155,13 @@
       "unconventional-seed-title": "Posible error",
       "unconventional-seed-text": "Usted introdujo una semilla no convencional. Si lo hizo por alguna razón en especial, puede continuar (sólo recomendable para usuarios avanzados). Sin embargo, si su intención es utilizar una semilla normal del sistema, usted debe borrar los textos y/o caracteres especiales adicionales.",
       "unconventional-seed-check": "Continuar con la semilla no convencional."
+    },
+
+    "scan": {
+      "connection-error": "No es posible conectar con el servidor. Por favor, vuelva a intentarlo luego.",
+      "unsynchronized-node-error": "No es posible restaurar las direcciones debido a que el servidor no está sincronizado. Por favor, vuelva a intentarlo luego.",
+      "title": "Restaurando las direcciones",
+      "message": "Restauradas hasta ahora:"
     },
 
     "unlock": {
@@ -299,7 +306,8 @@
       "wallet-exists": "Ya hay una billetera con esa semilla",
       "not-enough-hours1": "¡No cuenta con suficientes",
       "not-enough-hours2": "para realizar la operación!",
-      "wrong-seed": "Semilla incorrecta"
+      "wrong-seed": "Semilla incorrecta",
+      "invalid-wallet": "Billetera inválida"
     }
   }
 }


### PR DESCRIPTION
Changes:
- When loading a wallet, the addresses are scanned and those with transactions are added. The procedure scans addresses sequentially and stops when it have already reviewed 10 consecutive addresses without transactions or when it have already reviewed a total of 100 addresses, whichever happens first.
