### PR TITLE
Scan the addresses when loading a wallet

### DIFF
--- a/.angular-cli.json
+++ b/.angular-cli.json
@@ -30,7 +30,7 @@
       "environments": {
         "dev": "environments/environment.ts",
         "prod": "environments/environment.prod.ts",
-        "cipher-test": "environments/environment.cipher-test.ts"
+        "e2e": "environments/environment.e2e.ts"
       }
     }
   ],

--- a/e2e/onboarding-create.po.ts
+++ b/e2e/onboarding-create.po.ts
@@ -236,6 +236,6 @@ export class OnboardingCreatePage {
   }
 
   private waitUntilWalletIsCreated() {
-    browser.wait(ExpectedConditions.invisibilityOf(element(by.buttonText('Create'))), 20000);
+    browser.wait(ExpectedConditions.invisibilityOf(element(by.buttonText('Create'))), 30000);
   }
 }

--- a/e2e/wallets.po.ts
+++ b/e2e/wallets.po.ts
@@ -159,7 +159,7 @@ export class WalletsPage {
         return lastRecord.element(by.css('.address-column')).getText().then((address) => {
           return address === 'bSp3JvfGiHzumCpdaWT7tGRtejwhLDd2zv';
         });
-      }, 5000);
+      }, 10000);
     });
   }
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "start": "ng serve --proxy-config proxy.config.js",
     "build": "ng build --prod",
     "lint": "ng lint",
-    "e2e": "ng e2e --proxy-config proxy.config.js",
+    "e2e": "ng e2e --proxy-config proxy.config.js --environment e2e",
     "snyk-protect": "snyk protect",
     "protractor": "protractor protractor.conf.js",
     "test": "ng test -sm=false --watch=false --browsers ChromeHeadlessNoSandbox",
@@ -16,7 +16,7 @@
     "test:watch": "ng test -sm=false --browsers Chrome",
     "prepare": "npm run snyk-protect",
     "start-docker": "ng serve --proxy-config docker-proxy.config.js",
-    "e2e-docker": "ng e2e --proxy-config docker-proxy.config.js"
+    "e2e-docker": "ng e2e --proxy-config docker-proxy.config.js --environment e2e"
   },
   "private": true,
   "dependencies": {

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -79,6 +79,7 @@ import { BalanceService } from './services/wallet/balance.service';
 import { HistoryService } from './services/wallet/history.service';
 import { SpendingService } from './services/wallet/spending.service';
 import { CreateWalletFormComponent } from './components/pages/wallets/create-wallet/create-wallet-form/create-wallet-form.component';
+import { ScanAddressesComponent } from './components/pages/wallets/scan-addresses/scan-addresses.component';
 
 @NgModule({
   declarations: [
@@ -119,7 +120,8 @@ import { CreateWalletFormComponent } from './components/pages/wallets/create-wal
     CoinButtonComponent,
     SelectCoinOverlayComponent,
     SelectLanguageComponent,
-    CreateWalletFormComponent
+    CreateWalletFormComponent,
+    ScanAddressesComponent
   ],
   entryComponents: [
     AddDepositAddressComponent,
@@ -130,7 +132,8 @@ import { CreateWalletFormComponent } from './components/pages/wallets/create-wal
     TransactionDetailComponent,
     ConfirmationComponent,
     SelectCoinOverlayComponent,
-    SelectLanguageComponent
+    SelectLanguageComponent,
+    ScanAddressesComponent
   ],
   imports: [
     BrowserModule,

--- a/src/app/components/pages/onboarding/onboarding-create-wallet/onboarding-create-wallet.component.spec.ts
+++ b/src/app/components/pages/onboarding/onboarding-create-wallet/onboarding-create-wallet.component.spec.ts
@@ -4,14 +4,15 @@ import { MatDialogModule, MatSnackBarModule } from '@angular/material';
 import { RouterTestingModule } from '@angular/router/testing';
 import { FormBuilder } from '@angular/forms';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
-import { BrowserDynamicTestingModule } from '@angular/platform-browser-dynamic/testing';
+import { TranslateService } from '@ngx-translate/core';
 
 import { OnboardingCreateWalletComponent } from './onboarding-create-wallet.component';
 import { WalletService } from '../../../../services/wallet/wallet.service';
 import { CoinService } from '../../../../services/coin.service';
-import { MockTranslatePipe, MockWalletService, MockCoinService, MockLanguageService } from '../../../../utils/test-mocks';
+import { MockTranslatePipe, MockWalletService, MockCoinService, MockLanguageService, MockBlockchainService } from '../../../../utils/test-mocks';
 import { LanguageService } from '../../../../services/language.service';
 import { CreateWalletFormComponent } from '../../wallets/create-wallet/create-wallet-form/create-wallet-form.component';
+import { BlockchainService } from '../../../../services/blockchain.service';
 
 describe('OnboardingCreateWalletComponent', () => {
   let component: OnboardingCreateWalletComponent;
@@ -34,7 +35,12 @@ describe('OnboardingCreateWalletComponent', () => {
         FormBuilder,
         { provide: WalletService, useClass: MockWalletService },
         { provide: CoinService, useClass: MockCoinService },
-        { provide: LanguageService, useClass: MockLanguageService }
+        { provide: LanguageService, useClass: MockLanguageService },
+        { provide: BlockchainService, useClass: MockBlockchainService },
+        {
+          provide: TranslateService,
+          useValue: jasmine.createSpyObj('TranslateService', ['instant'])
+        },
       ],
       schemas: [ NO_ERRORS_SCHEMA ]
     });

--- a/src/app/components/pages/wallets/create-wallet/create-wallet.component.spec.ts
+++ b/src/app/components/pages/wallets/create-wallet/create-wallet.component.spec.ts
@@ -1,11 +1,13 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { NO_ERRORS_SCHEMA } from '@angular/core';
-import { MAT_DIALOG_DATA, MatDialogRef, MatSnackBarModule } from '@angular/material';
+import { MAT_DIALOG_DATA, MatDialogRef, MatSnackBarModule, MatDialogModule } from '@angular/material';
+import { TranslateService } from '@ngx-translate/core';
 
 import { CreateWalletComponent } from './create-wallet.component';
 import { WalletService } from '../../../../services/wallet/wallet.service';
 import { CoinService } from '../../../../services/coin.service';
-import { MockTranslatePipe, MockWalletService, MockCoinService } from '../../../../utils/test-mocks';
+import { MockTranslatePipe, MockWalletService, MockCoinService, MockBlockchainService } from '../../../../utils/test-mocks';
+import { BlockchainService } from '../../../../services/blockchain.service';
 
 describe('CreateWalletComponent', () => {
   let component: CreateWalletComponent;
@@ -14,13 +16,18 @@ describe('CreateWalletComponent', () => {
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       declarations: [ CreateWalletComponent, MockTranslatePipe ],
-      imports: [ MatSnackBarModule ],
+      imports: [ MatSnackBarModule, MatDialogModule ],
       schemas: [ NO_ERRORS_SCHEMA ],
       providers: [
         { provide: MAT_DIALOG_DATA, useValue: {} },
         { provide: WalletService, useClass: MockWalletService },
         { provide: MatDialogRef, useValue: {} },
-        { provide: CoinService, useClass: MockCoinService }
+        { provide: CoinService, useClass: MockCoinService },
+        { provide: BlockchainService, useClass: MockBlockchainService },
+        {
+          provide: TranslateService,
+          useValue: jasmine.createSpyObj('TranslateService', ['instant'])
+        },
       ]
     })
     .compileComponents();

--- a/src/app/components/pages/wallets/scan-addresses/scan-addresses.component.html
+++ b/src/app/components/pages/wallets/scan-addresses/scan-addresses.component.html
@@ -1,0 +1,10 @@
+<app-modal class="modal" [headline]="'wallet.scan.title' | translate"
+           [dialog]="dialogRef"
+           [disableDismiss]="true"
+           [loadingProgress]="progress.progress">
+
+  <div class="-body">
+    {{ 'wallet.scan.message' | translate }} {{ progress.addressesFound }}
+  </div>
+  
+</app-modal>

--- a/src/app/components/pages/wallets/scan-addresses/scan-addresses.component.spec.ts
+++ b/src/app/components/pages/wallets/scan-addresses/scan-addresses.component.spec.ts
@@ -1,0 +1,37 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { NO_ERRORS_SCHEMA } from '@angular/core';
+import { MAT_DIALOG_DATA, MatDialogRef, MatSnackBar } from '@angular/material';
+import { FormBuilder } from '@angular/forms';
+
+import { ScanAddressesComponent } from './scan-addresses.component';
+import { WalletService } from '../../../../services/wallet/wallet.service';
+import { MockTranslatePipe, MockWalletService } from '../../../../utils/test-mocks';
+
+describe('ScanAddressesComponent', () => {
+  let component: ScanAddressesComponent;
+  let fixture: ComponentFixture<ScanAddressesComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ ScanAddressesComponent, MockTranslatePipe ],
+      schemas: [ NO_ERRORS_SCHEMA ],
+      providers: [
+        FormBuilder,
+        { provide: WalletService, useClass: MockWalletService },
+        { provide: MatDialogRef, useValue: {} },
+        { provide: MAT_DIALOG_DATA, useValue: {} },
+      ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(ScanAddressesComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should be created', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/components/pages/wallets/scan-addresses/scan-addresses.component.ts
+++ b/src/app/components/pages/wallets/scan-addresses/scan-addresses.component.ts
@@ -1,0 +1,49 @@
+import { Component, EventEmitter, Inject, OnInit, Output, ViewChild, OnDestroy } from '@angular/core';
+import { FormBuilder, FormGroup, Validators } from '@angular/forms';
+import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
+import { MatSnackBar, MatSnackBarConfig } from '@angular/material/snack-bar';
+import { Subscription } from 'rxjs/Subscription';
+
+import { Wallet } from '../../../../app.datatypes';
+import { WalletService, ScanProgressData } from '../../../../services/wallet/wallet.service';
+
+@Component({
+  selector: 'app-scan-addresses',
+  templateUrl: './scan-addresses.component.html',
+  styleUrls: ['./scan-addresses.component.scss'],
+})
+export class ScanAddressesComponent implements OnInit, OnDestroy {
+  progress = new ScanProgressData();
+
+  private subscription: Subscription;
+
+  constructor(
+    @Inject(MAT_DIALOG_DATA) private data: Wallet,
+    public dialogRef: MatDialogRef<ScanAddressesComponent>,
+    private walletService: WalletService
+  ) {}
+
+  ngOnInit() {
+    this.scan();
+  }
+
+  ngOnDestroy() {
+    this.subscription.unsubscribe();
+  }
+
+  closePopup(result = null) {
+    this.dialogRef.close(result);
+  }
+
+  scan() {
+    const onProgressChanged = new EventEmitter<ScanProgressData>();
+    this.subscription = onProgressChanged.subscribe((progress: ScanProgressData) => this.progress = progress);
+
+    this.subscription.add(this.walletService.scanAddresses(this.data, onProgressChanged)
+      .subscribe(
+        () => this.closePopup(null),
+        (error: Error) => this.closePopup(error)
+      )
+    );
+  }
+}

--- a/src/app/services/api.service.ts
+++ b/src/app/services/api.service.ts
@@ -71,7 +71,7 @@ export class ApiService {
   }
 
   private getErrorMessage(error: any): Observable<string> {
-    if (error.error) {
+    if (error.error && typeof error.error === 'string') {
       return Observable.throw(new Error(parseResponseMessage(error.error.trim())));
     } if (error.message) {
       return Observable.throw(new Error(parseResponseMessage(error.message.trim())));

--- a/src/app/services/blockchain.service.ts
+++ b/src/app/services/blockchain.service.ts
@@ -9,6 +9,7 @@ import { ApiService } from './api.service';
 import { BalanceService } from './wallet/balance.service';
 import { ConnectionError } from '../enums/connection-error.enum';
 import { CoinService } from './coin.service';
+import { environment } from '../../environments/environment';
 
 export enum ProgressStates {
   Progress,
@@ -108,7 +109,7 @@ export class BlockchainService {
   private checkConnectionState(): Observable<any> {
     return this.apiService.get('network/connections')
       .map((status: any) => {
-        if (!status.connections || status.connections.length === 0) {
+        if ((!status.connections || status.connections.length === 0) && !environment.e2eTest) {
           this.onLoadBlockchainError(ConnectionError.NO_ACTIVE_CONNECTIONS);
           throw { reported: true };
         }

--- a/src/app/services/wallet/wallet.service.spec.ts
+++ b/src/app/services/wallet/wallet.service.spec.ts
@@ -9,6 +9,7 @@ import { CipherProvider } from '../cipher.provider';
 import { CoinService } from '../coin.service';
 import { EventEmitter } from '@angular/core';
 import { MockCoinService } from '../../utils/test-mocks';
+import { ApiService } from '../api.service';
 import {
   Wallet,
   Address } from '../../app.datatypes';
@@ -33,6 +34,12 @@ describe('WalletService', () => {
         {
           provide: TranslateService,
           useValue: jasmine.createSpyObj('TranslateService', ['instant'])
+        },
+        {
+          provide: ApiService,
+          useValue: jasmine.createSpyObj('ApiService', {
+            'get': Observable.of([])
+          })
         },
         { provide: CoinService, useClass: MockCoinService }
       ]

--- a/src/app/services/wallet/wallet.service.ts
+++ b/src/app/services/wallet/wallet.service.ts
@@ -10,6 +10,13 @@ import { convertAsciiToHexa } from '../../utils/converters';
 import { defaultCoinId } from '../../constants/coins-id.const';
 import { BaseCoin } from '../../coins/basecoin';
 import { CoinService } from '../coin.service';
+import { ApiService } from '../api.service';
+import { environment } from '../../../environments/environment';
+
+export class ScanProgressData {
+  addressesFound = 1;
+  progress = 0;
+}
 
 @Injectable()
 export class WalletService {
@@ -21,6 +28,7 @@ export class WalletService {
     private cipherProvider: CipherProvider,
     private translate: TranslateService,
     private coinService: CoinService,
+    private apiService: ApiService,
   ) {
     this.loadWallets();
     this.coinService.currentCoin.subscribe((coin) => this.currentCoin = coin);
@@ -41,7 +49,7 @@ export class WalletService {
     return this.currentWallets.map(wallets => wallets.reduce((array, wallet) => array.concat(wallet.addresses), []));
   }
 
-  addAddress(wallet: Wallet): Observable<void> {
+  addAddress(wallet: Wallet, saveWallet = true): Observable<void> {
     if (!wallet.seed || !wallet.addresses[wallet.addresses.length - 1].next_seed) {
       throw new Error(this.translate.instant('service.wallet.address-without-seed'));
     }
@@ -51,11 +59,13 @@ export class WalletService {
     return this.cipherProvider.generateAddress(lastSeed)
       .map((addr: Address) => {
         wallet.addresses.push(addr);
-        this.saveWallets();
+        if (saveWallet) {
+          this.saveWallets();
+        }
       });
   }
 
-  create(label: string, seed: string, coinId: number): Observable<void> {
+  create(label: string, seed: string, coinId: number, save = true): Observable<Wallet> {
     seed = this.getCleanSeed(seed);
 
     return this.cipherProvider.generateAddress(convertAsciiToHexa(seed))
@@ -75,9 +85,17 @@ export class WalletService {
           throw new Error(this.translate.instant('service.wallet.wallet-exists'));
         }
 
-        this.wallets.value.push(wallet);
-        this.saveWallets();
+        if (save) {
+          this.add(wallet);
+        }
+
+        return wallet;
       });
+  }
+
+  add(wallet: Wallet) {
+    this.wallets.value.push(wallet);
+    this.saveWallets();
   }
 
   delete(wallet: Wallet) {
@@ -87,6 +105,27 @@ export class WalletService {
 
       this.saveWallets();
     }
+  }
+
+  scanAddresses(wallet: Wallet, onProgressChanged: EventEmitter<ScanProgressData>): Observable<void> {
+    if (wallet.addresses.length !== 1) {
+      throw new Error(this.translate.instant('service.wallet.invalid-wallet'));
+    }
+
+    return this.checkWalletAddresses(wallet, 0, onProgressChanged)
+      .map(lastIndexWithTxs => {
+        const unnecessaryAddresses = wallet.addresses.length - 1 - lastIndexWithTxs;
+        if (unnecessaryAddresses > 0) {
+          wallet.addresses.splice(lastIndexWithTxs + 1, unnecessaryAddresses);
+        }
+        this.saveWallets();
+      })
+      .catch(error => {
+        if (wallet.addresses.length > 1) {
+          wallet.addresses.splice(1, wallet.addresses.length - 1);
+        }
+        return Observable.throw(error);
+      });
   }
 
   unlockWallet(wallet: Wallet, seed: string, onProgressChanged: EventEmitter<number>): Observable<void> {
@@ -129,6 +168,30 @@ export class WalletService {
 
   private getCleanSeed(seed: string): string {
     return seed.replace(/(\n|\r\n)$/, '');
+  }
+
+  private checkWalletAddresses(wallet: Wallet, lastIndexWithTxs: number, onProgressChanged: EventEmitter<ScanProgressData>): Observable<number> {
+    const minAdrressesToScan = environment.e2eTest ? 2 : 10;
+    const maxAdrressesToScan = environment.e2eTest ? 2 : 100;
+
+    return this.addAddress(wallet, false)
+      .flatMap(() => this.apiService.get('explorer/address', { address: wallet.addresses[wallet.addresses.length - 1].address }))
+      .flatMap(transactions => {
+        if (transactions && transactions.length > 0) {
+          lastIndexWithTxs = wallet.addresses.length - 1;
+        }
+
+        onProgressChanged.emit({
+          addressesFound: lastIndexWithTxs + 1,
+          progress: (wallet.addresses.length - 1 - lastIndexWithTxs) / minAdrressesToScan * 100
+        });
+
+        if (lastIndexWithTxs + minAdrressesToScan === wallet.addresses.length - 1 || wallet.addresses.length === maxAdrressesToScan) {
+          return Observable.of(lastIndexWithTxs);
+        } else {
+          return this.checkWalletAddresses(wallet, lastIndexWithTxs, onProgressChanged);
+        }
+      });
   }
 
   private unlockWalletAddresses(currentSeed: string, wallet: Wallet, index: number, onProgressChanged: EventEmitter<number>): Observable<boolean> {

--- a/src/app/utils/test-mocks.ts
+++ b/src/app/utils/test-mocks.ts
@@ -91,6 +91,10 @@ export class MockWalletService {
   get currentWallets(): Observable<Wallet[]> {
     return Observable.of([]);
   }
+
+  scanAddresses(wallet, onProgressChanged): Observable<void> {
+    return Observable.of();
+  }
 }
 
 export class MockHistoryService {

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -157,6 +157,13 @@
       "unconventional-seed-check": "Continue with the unconventional seed."
     },
 
+    "scan": {
+      "connection-error": "It is not possible to connect to the server. Please try again later.",
+      "unsynchronized-node-error": "It is not possible to restore the addresses because the server is not synchronized. Please try again later.",
+      "title": "Restoring addresses",
+      "message": "Restored until now:"
+    },
+
     "unlock": {
       "unlock-title": "Unlock Wallet",
       "seed": "Seed",
@@ -299,7 +306,8 @@
       "wallet-exists": "A wallet already exists with this seed",
       "not-enough-hours1": "Not enough available",
       "not-enough-hours2": "to perform transaction!",
-      "wrong-seed": "Wrong seed"
+      "wrong-seed": "Wrong seed",
+      "invalid-wallet": "Invalid wallet"
     }
   }
 }

--- a/src/assets/i18n/es.json
+++ b/src/assets/i18n/es.json
@@ -104,7 +104,7 @@
     "confirm": {
       "title": "¡Resguarde su semilla!",
       "desc": "Queremos asegurarnos de que ha anotado su semilla y la ha almacenado en un lugar seguro. ¡Si olvida su semilla, NO podrá recuperar su billetera!",
-      "checkbox": "Está segura, lo aseguro.",
+      "checkbox": "Está segura, lo garantizo.",
       "button": "Continuar"
     }
   },
@@ -155,6 +155,13 @@
       "unconventional-seed-title": "Posible error",
       "unconventional-seed-text": "Usted introdujo una semilla no convencional. Si lo hizo por alguna razón en especial, puede continuar (sólo recomendable para usuarios avanzados). Sin embargo, si su intención es utilizar una semilla normal del sistema, usted debe borrar los textos y/o caracteres especiales adicionales.",
       "unconventional-seed-check": "Continuar con la semilla no convencional."
+    },
+
+    "scan": {
+      "connection-error": "No es posible conectar con el servidor. Por favor, vuelva a intentarlo luego.",
+      "unsynchronized-node-error": "No es posible restaurar las direcciones debido a que el servidor no está sincronizado. Por favor, vuelva a intentarlo luego.",
+      "title": "Restaurando las direcciones",
+      "message": "Restauradas hasta ahora:"
     },
 
     "unlock": {
@@ -299,7 +306,8 @@
       "wallet-exists": "Ya hay una billetera con esa semilla",
       "not-enough-hours1": "¡No cuenta con suficientes",
       "not-enough-hours2": "para realizar la operación!",
-      "wrong-seed": "Semilla incorrecta"
+      "wrong-seed": "Semilla incorrecta",
+      "invalid-wallet": "Billetera inválida"
     }
   }
 }

--- a/src/environments/environment.e2e.ts
+++ b/src/environments/environment.e2e.ts
@@ -1,4 +1,4 @@
 export const environment = {
   production: false,
-  e2eTest: false,
+  e2eTest: true,
 };

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -1,3 +1,4 @@
 export const environment = {
-  production: true
+  production: true,
+  e2eTest: false,
 };


### PR DESCRIPTION
Changes:
- When loading a wallet, the addresses are scanned and those with transactions are added. The procedure scans addresses sequentially and stops when it have already reviewed 10 consecutive addresses without transactions or when it have already reviewed a total of 100 addresses, whichever happens first.
- Some fixes for the e2e tests.