### PR TITLE
Prepare for a test server

### DIFF
--- a/e2e/onboarding-create.e2e-spec.ts
+++ b/e2e/onboarding-create.e2e-spec.ts
@@ -118,7 +118,7 @@ describe('Onboarding Create', () => {
   });
 
   it('should load wallet with correct address', done => {
-    browser.get('/wizard');
+    browser.get('#/wizard');
     expect<any>(page.verifyLoadedWalletAddress()).toEqual(true);
     done();
   });

--- a/e2e/onboarding-create.po.ts
+++ b/e2e/onboarding-create.po.ts
@@ -2,7 +2,7 @@ import { browser, by, element, ElementFinder, ExpectedConditions } from 'protrac
 
 export class OnboardingCreatePage {
   navigateTo() {
-    return browser.get('/wizard/create');
+    return browser.get('#/wizard/create');
   }
 
   getHeaderText() {

--- a/e2e/send_sky.po.ts
+++ b/e2e/send_sky.po.ts
@@ -2,7 +2,7 @@ import { browser, by, element } from 'protractor';
 
 export class SendSkyPage {
   navigateTo() {
-    return browser.get('/send');
+    return browser.get('#/send');
   }
 
   getHeaderText() {

--- a/e2e/transactions.po.ts
+++ b/e2e/transactions.po.ts
@@ -2,7 +2,7 @@ import { browser, by, element } from 'protractor';
 
 export class TransactionsPage {
   navigateTo() {
-    return browser.get('/history');
+    return browser.get('#/history');
   }
 
   getHeaderText() {

--- a/e2e/wallets.po.ts
+++ b/e2e/wallets.po.ts
@@ -2,7 +2,7 @@ import { browser, by, element, ExpectedConditions } from 'protractor';
 
 export class WalletsPage {
   navigateTo() {
-    return browser.get('/wallets');
+    return browser.get('#/wallets');
   }
 
   getHeaderText() {

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -158,7 +158,7 @@ import { ScanAddressesComponent } from './components/pages/wallets/scan-addresse
     NoopAnimationsModule,
     ReactiveFormsModule,
     FormsModule,
-    RouterModule.forRoot(AppRoutes),
+    RouterModule.forRoot(AppRoutes, { useHash: true }),
     FeatureToggleModule,
     TranslateModule.forRoot({
       loader: {

--- a/src/app/services/coin.service.ts
+++ b/src/app/services/coin.service.ts
@@ -4,6 +4,7 @@ import { BaseCoin } from '../coins/basecoin';
 import { SkycoinCoin } from '../coins/skycoin.coin';
 import { TestCoin } from '../coins/test.coin';
 import { defaultCoinId } from '../constants/coins-id.const';
+import { environment } from '../../environments/environment';
 
 export class CoinService {
 
@@ -40,8 +41,9 @@ export class CoinService {
   private loadAvailableCoins() {
     this.coins.push(new SkycoinCoin());
 
-    // Uncomment the next line to add the test coin.
-    // this.coins.push(new TestCoin());
+    if (!environment.production) {
+      this.coins.push(new TestCoin());
+    }
 
     const IDs = new Map<number, boolean>();
     this.coins.forEach((value: BaseCoin) => {

--- a/src/app/services/coin.service.ts
+++ b/src/app/services/coin.service.ts
@@ -38,7 +38,10 @@ export class CoinService {
   }
 
   private loadAvailableCoins() {
-    this.coins.push(new SkycoinCoin(), new TestCoin());
+    this.coins.push(new SkycoinCoin());
+
+    // Uncomment the next line to add the test coin.
+    // this.coins.push(new TestCoin());
 
     const IDs = new Map<number, boolean>();
     this.coins.forEach((value: BaseCoin) => {


### PR DESCRIPTION
In preparation for uploading the wallet to a server for testing, this PR disables Testcoin. This means that the options for changing the coin will be hidden in the UI, since only one coin would be available (Skycoin). It is possible to reactivate Testcoin simply by uncommenting a line of code, in case it is necessary for testing.

Update 1: now Testcoin is only hidden in production builds

Update 2: the style of the URLs was changed to `HashLocationStrategy`, to avoid having to make additional configurations to the server.