### PR TITLE
Remove yarn from the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,7 @@ The Skycoin web interface requires Node 6.9.0 or higher, together with NPM 3 or 
 
 This project is generated using Angular CLI, therefore it is adviced to first run `npm install -g @angular/cli`.
 
-Dependencies are managed with Yarn, to install yarn run `npm install -g yarn`.
-
-To install all Angular, Angular CLI and all other libraries, you will then have to run `yarn`.
+To install all Angular, Angular CLI and all other libraries, you will have to run `npm install`.
 
 You will only have to run this again, if any dependencies have been changed in the `package.json` file.
 


### PR DESCRIPTION
Changes:
- Remove the references to Yarn from the readme. Yarn stopped being used in https://github.com/skycoin/skycoin-web/commit/a0776d97924d1a0479e33fa1bdf9d731274851c8
