### PR TITLE
Remove yarn reference from Dockerfile and update Installation on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,7 @@ The Skycoin web interface requires Node 6.9.0 or higher, together with NPM 3 or 
 
 This project is generated using Angular CLI, therefore it is adviced to first run `npm install -g @angular/cli`.
 
-Dependencies are managed with Yarn, to install yarn run `npm install -g yarn`.
-
-To install all Angular, Angular CLI and all other libraries, you will then have to run `yarn`.
+To install all Angular, Angular CLI and all other libraries, you will then have to run `npm install`.
 
 You will only have to run this again, if any dependencies have been changed in the `package.json` file.
 

--- a/docker/images/Dockerfile
+++ b/docker/images/Dockerfile
@@ -5,7 +5,7 @@ COPY . /usr/src/skycoin-web
 WORKDIR /usr/src/skycoin-web
 
 RUN npm install -g @angular/cli \
-    && yarn \
+    && npm install \
     && npm run build
 
 FROM nginx:alpine


### PR DESCRIPTION
Fixes #478 

Changes: Remove yarn from README file and use npm instead of yarn to build docker image 
-
