### PR TITLE
Use v0.25.0 api

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -80,6 +80,7 @@ import { CreateWalletFormComponent } from './components/pages/wallets/create-wal
 import { ScanAddressesComponent } from './components/pages/wallets/scan-addresses/scan-addresses.component';
 import { NodesComponent } from './components/pages/settings/nodes/nodes.component';
 import { ChangeNodeURLComponent } from './components/pages/settings/nodes/change-url/change-node-url.component';
+import { GlobalsService } from './services/globals.service';
 
 @NgModule({
   declarations: [
@@ -183,7 +184,8 @@ import { ChangeNodeURLComponent } from './components/pages/settings/nodes/change
     WalletService,
     BalanceService,
     HistoryService,
-    SpendingService
+    SpendingService,
+    GlobalsService
   ],
   bootstrap: [AppComponent],
 })

--- a/src/app/components/pages/settings/pending-transactions/pending-transactions.component.spec.ts
+++ b/src/app/components/pages/settings/pending-transactions/pending-transactions.component.spec.ts
@@ -6,13 +6,15 @@ import { WalletService } from '../../../../services/wallet/wallet.service';
 import { HistoryService } from '../../../../services/wallet/history.service';
 import { NavBarService } from '../../../../services/nav-bar.service';
 import { CoinService } from '../../../../services/coin.service';
+import { GlobalsService } from '../../../../services/globals.service';
 import {
   MockTranslatePipe,
   MockDateTimePipe,
   MockNavBarService,
   MockCoinService,
   MockWalletService,
-  MockHistoryService
+  MockHistoryService,
+  MockGlobalsService
 } from '../../../../utils/test-mocks';
 
 describe('PendingTransactionsComponent', () => {
@@ -31,7 +33,8 @@ describe('PendingTransactionsComponent', () => {
         { provide: WalletService, useClass: MockWalletService },
         { provide: HistoryService, useClass: MockHistoryService },
         { provide: NavBarService, useClass: MockNavBarService },
-        { provide: CoinService, useClass: MockCoinService }
+        { provide: CoinService, useClass: MockCoinService },
+        { provide: GlobalsService, useClass: MockGlobalsService }
       ]
     }).compileComponents();
   }));

--- a/src/app/components/pages/settings/pending-transactions/pending-transactions.component.ts
+++ b/src/app/components/pages/settings/pending-transactions/pending-transactions.component.ts
@@ -10,6 +10,8 @@ import { Wallet } from '../../../../app.datatypes';
 import { Observable } from 'rxjs/Observable';
 import { BaseCoin } from '../../../../coins/basecoin';
 import { CoinService } from '../../../../services/coin.service';
+import { GlobalsService } from '../../../../services/globals.service';
+import { isEqualOrSuperiorVersion } from '../../../../utils/semver';
 
 @Component({
   selector: 'app-pending-transactions',
@@ -30,7 +32,8 @@ export class PendingTransactionsComponent implements OnInit, OnDestroy {
     private walletService: WalletService,
     private historyService: HistoryService,
     private navbarService: NavBarService,
-    private coinService: CoinService
+    private coinService: CoinService,
+    private globalsService: GlobalsService
   ) { }
 
   ngOnInit() {
@@ -92,18 +95,30 @@ export class PendingTransactionsComponent implements OnInit, OnDestroy {
       return Observable.of([]);
     }
 
-    const allTransactions = this.getUpdatedTransactions(transactions);
+    return this.globalsService.nodeVersion.filter(version => version !== null).first().flatMap (version => {
+      let allTransactions: Observable<any>;
+      if (isEqualOrSuperiorVersion(version, '0.25.0')) {
+        allTransactions = Observable.of(transactions);
+      } else {
+        allTransactions = this.getUpdatedTransactions(transactions);
+      }
 
-    return Observable.forkJoin(allTransactions, this.walletService.currentWallets.first(), (trans: any, wallets: Wallet[]) => {
-      const walletAddresses = new Set<string>();
-      wallets.forEach(wallet => {
-        wallet.addresses.forEach(address => walletAddresses.add(address.address));
+      return Observable.forkJoin(allTransactions, this.walletService.currentWallets.first(), (trans: any, wallets: Wallet[]) => {
+        const walletAddresses = new Set<string>();
+        wallets.forEach(wallet => {
+          wallet.addresses.forEach(address => walletAddresses.add(address.address));
+        });
+
+        return trans.filter(tran => {
+          if (isEqualOrSuperiorVersion(version, '0.25.0')) {
+            return tran.transaction.inputs.some(input => walletAddresses.has(input.owner)) ||
+            tran.transaction.outputs.some(output => walletAddresses.has(output.dst));
+          } else {
+            return tran.owner_addressses.some(address => walletAddresses.has(address)) ||
+            tran.transaction.outputs.some(output => walletAddresses.has(output.dst));
+          }
+        });
       });
-
-      return trans.filter(tran =>
-        tran.owner_addressses.some(address => walletAddresses.has(address)) ||
-        tran.transaction.outputs.some(output => walletAddresses.has(output.dst))
-      );
     });
   }
 

--- a/src/app/components/pages/settings/pending-transactions/pending-transactions.component.ts
+++ b/src/app/components/pages/settings/pending-transactions/pending-transactions.component.ts
@@ -95,7 +95,7 @@ export class PendingTransactionsComponent implements OnInit, OnDestroy {
       return Observable.of([]);
     }
 
-    return this.globalsService.nodeVersion.filter(version => version !== null).first().flatMap (version => {
+    return this.globalsService.getValidNodeVersion().flatMap (version => {
       let allTransactions: Observable<any>;
       if (isEqualOrSuperiorVersion(version, '0.25.0')) {
         allTransactions = Observable.of(transactions);

--- a/src/app/services/api.service.ts
+++ b/src/app/services/api.service.ts
@@ -30,23 +30,12 @@ export class ApiService {
       .catch((error: any) => this.getErrorMessage(error));
   }
 
-  post(url, body = {}, options: any = {}, requestCsrf: boolean = false): Observable<any> {
-    if (requestCsrf) {
-      return this.getCsrf().first().flatMap(csrf => {
-        options.csrf = csrf;
-        return this.http.post(
-          this.getUrl(url),
-          options.json ? JSON.stringify(body) : this.getQueryString(body),
-          this.getRequestOptions(options)
-        ).catch((error: any) => this.getErrorMessage(error));
-      });
-    } else {
-      return this.http.post(
-        this.getUrl(url),
-        options.json ? JSON.stringify(body) : this.getQueryString(body),
-        this.getRequestOptions(options)
-      ).catch((error: any) => this.getErrorMessage(error));
-    }
+  post(url, body = {}, options: any = {}): Observable<any> {
+    return this.http.post(
+      this.getUrl(url),
+      options.json ? JSON.stringify(body) : this.getQueryString(body),
+      this.getRequestOptions(options)
+    ).catch((error: any) => this.getErrorMessage(error));
   }
 
   private getQueryString(parameters = null) {

--- a/src/app/services/api.service.ts
+++ b/src/app/services/api.service.ts
@@ -34,13 +34,31 @@ export class ApiService {
     if (requestCsrf) {
       return this.getCsrf().first().flatMap(csrf => {
         options.csrf = csrf;
-        return this.http.post(this.getUrl(url), body, this.getRequestOptions(options))
-          .catch((error: any) => this.getErrorMessage(error));
+        return this.http.post(
+          this.getUrl(url),
+          options.json ? JSON.stringify(body) : this.getQueryString(body),
+          this.getRequestOptions(options)
+        ).catch((error: any) => this.getErrorMessage(error));
       });
     } else {
-      return this.http.post(this.getUrl(url), body, this.getRequestOptions(options))
-        .catch((error: any) => this.getErrorMessage(error));
+      return this.http.post(
+        this.getUrl(url),
+        options.json ? JSON.stringify(body) : this.getQueryString(body),
+        this.getRequestOptions(options)
+      ).catch((error: any) => this.getErrorMessage(error));
     }
+  }
+
+  private getQueryString(parameters = null) {
+    if (!parameters) {
+      return '';
+    }
+
+    return Object.keys(parameters).reduce((array, key) => {
+      array.push(key + '=' + encodeURIComponent(parameters[key]));
+
+      return array;
+    }, []).join('&');
   }
 
   private getRequestOptions(additionalOptions: any, parameters: any = null): any {
@@ -48,7 +66,7 @@ export class ApiService {
     options.params = this.getQueryStringParams(parameters);
     options.headers = new HttpHeaders();
 
-    options.headers = options.headers.append('Content-Type', 'application/json');
+    options.headers = options.headers.append('Content-Type', additionalOptions.json ? 'application/json' : 'application/x-www-form-urlencoded');
 
     if (additionalOptions.csrf) {
       options.headers = options.headers.append('X-CSRF-Token', additionalOptions.csrf);

--- a/src/app/services/blockchain.service.spec.ts
+++ b/src/app/services/blockchain.service.spec.ts
@@ -3,8 +3,9 @@ import { TestBed, inject } from '@angular/core/testing';
 import { BlockchainService } from './blockchain.service';
 import { ApiService } from './api.service';
 import { BalanceService } from './wallet/balance.service';
-import { MockApiService, MockBalanceService, MockCoinService } from '../utils/test-mocks';
+import { MockApiService, MockBalanceService, MockCoinService, MockGlobalsService } from '../utils/test-mocks';
 import { CoinService } from './coin.service';
+import { GlobalsService } from './globals.service';
 
 describe('BlockchainService', () => {
   let service: BlockchainService;
@@ -17,7 +18,8 @@ describe('BlockchainService', () => {
         BlockchainService,
         { provide: ApiService, useClass: MockApiService },
         { provide: BalanceService, useClass: MockBalanceService },
-        { provide: CoinService, useClass: MockCoinService }
+        { provide: CoinService, useClass: MockCoinService },
+        { provide: GlobalsService, useClass: MockGlobalsService }
       ]
     });
   });

--- a/src/app/services/blockchain.service.ts
+++ b/src/app/services/blockchain.service.ts
@@ -10,6 +10,7 @@ import { BalanceService } from './wallet/balance.service';
 import { ConnectionError } from '../enums/connection-error.enum';
 import { CoinService } from './coin.service';
 import { environment } from '../../environments/environment';
+import { GlobalsService } from './globals.service';
 
 export enum ProgressStates {
   Progress,
@@ -26,8 +27,6 @@ export class ProgressEvent {
 
 @Injectable()
 export class BlockchainService {
-  nodeVersion: string;
-
   private progressSubject: BehaviorSubject<ProgressEvent> = new BehaviorSubject<ProgressEvent>(null);
   private connectionsSubscription: Subscription;
   private readonly defaultPeriod = 90000;
@@ -40,6 +39,7 @@ export class BlockchainService {
   constructor (
     private apiService: ApiService,
     private balanceService: BalanceService,
+    private globalsService: GlobalsService,
     coinService: CoinService
   ) {
     coinService.currentCoin.subscribe(() => {
@@ -63,6 +63,7 @@ export class BlockchainService {
 
     this.balanceService.stopGettingBalances();
 
+    this.globalsService.nodeVersion.next(null);
     this.progressSubject.next({ state: ProgressStates.Restarting });
 
     this.connectionsSubscription = this.checkConnectionState()
@@ -115,6 +116,6 @@ export class BlockchainService {
         }
       })
       .flatMap(() => this.apiService.get('version'))
-      .map ((response: any) => this.nodeVersion = response.version);
+      .map ((response: any) => this.globalsService.nodeVersion.next(response.version));
   }
 }

--- a/src/app/services/blockchain.service.ts
+++ b/src/app/services/blockchain.service.ts
@@ -63,7 +63,7 @@ export class BlockchainService {
 
     this.balanceService.stopGettingBalances();
 
-    this.globalsService.nodeVersion.next(null);
+    this.globalsService.setNodeVersion(null);
     this.progressSubject.next({ state: ProgressStates.Restarting });
 
     this.connectionsSubscription = this.checkConnectionState()
@@ -116,6 +116,6 @@ export class BlockchainService {
         }
       })
       .flatMap(() => this.apiService.get('version'))
-      .map ((response: any) => this.globalsService.nodeVersion.next(response.version));
+      .map ((response: any) => this.globalsService.setNodeVersion(response.version));
   }
 }

--- a/src/app/services/globals.service.ts
+++ b/src/app/services/globals.service.ts
@@ -1,0 +1,8 @@
+import { Injectable } from '@angular/core';
+import { BehaviorSubject } from 'rxjs/BehaviorSubject';
+
+// Add vars to this file when having problems with circular dependencies
+@Injectable()
+export class GlobalsService {
+  nodeVersion: BehaviorSubject<string> = new BehaviorSubject<string>(null);
+}

--- a/src/app/services/globals.service.ts
+++ b/src/app/services/globals.service.ts
@@ -1,8 +1,17 @@
 import { Injectable } from '@angular/core';
+import { Observable } from 'rxjs/Observable';
 import { BehaviorSubject } from 'rxjs/BehaviorSubject';
 
-// Add vars to this file when having problems with circular dependencies
+// Add vars and functions to this file when having problems with circular dependencies
 @Injectable()
 export class GlobalsService {
-  nodeVersion: BehaviorSubject<string> = new BehaviorSubject<string>(null);
+  private nodeVersion: BehaviorSubject<string> = new BehaviorSubject<string>(null);
+
+  setNodeVersion(version: string) {
+    this.nodeVersion.next(version);
+  }
+
+  getValidNodeVersion(): Observable<string> {
+    return this.nodeVersion.filter(version => version !== null).first();
+  }
 }

--- a/src/app/services/wallet/balance.service.ts
+++ b/src/app/services/wallet/balance.service.ts
@@ -101,7 +101,7 @@ export class BalanceService {
   private retrieveAddressesBalance(addresses: Address[]): Observable<Balance> {
     const formattedAddresses = addresses.map(a => a.address).join(',');
 
-    return this.globalsService.nodeVersion.filter(version => version !== null).first().flatMap (version => {
+    return this.globalsService.getValidNodeVersion().flatMap (version => {
       if (isEqualOrSuperiorVersion(version, '0.25.0')) {
         return this.apiService.post('balance', { addrs: formattedAddresses });
       } else {

--- a/src/app/services/wallet/balance.service.ts
+++ b/src/app/services/wallet/balance.service.ts
@@ -10,6 +10,8 @@ import { BigNumber } from 'bignumber.js';
 import { ApiService } from '../api.service';
 import { Address, Wallet, TotalBalance, Balance } from '../../app.datatypes';
 import { WalletService } from './wallet.service';
+import { isEqualOrSuperiorVersion } from '../../utils/semver';
+import { GlobalsService } from '../globals.service';
 
 export enum BalanceStates {
   Obtained,
@@ -38,6 +40,7 @@ export class BalanceService {
   constructor(
     private apiService: ApiService,
     private walletService: WalletService,
+    private globalsService: GlobalsService,
     private _ngZone: NgZone
   ) {
     walletService.wallets.subscribe(() => this.canGetBalance ? this.scheduleUpdate(0) : null);
@@ -97,7 +100,14 @@ export class BalanceService {
 
   private retrieveAddressesBalance(addresses: Address[]): Observable<Balance> {
     const formattedAddresses = addresses.map(a => a.address).join(',');
-    return this.apiService.get('balance', { addrs: formattedAddresses });
+
+    return this.globalsService.nodeVersion.filter(version => version !== null).first().flatMap (version => {
+      if (isEqualOrSuperiorVersion(version, '0.25.0')) {
+        return this.apiService.post('balance', { addrs: formattedAddresses });
+      } else {
+        return this.apiService.get('balance', { addrs: formattedAddresses });
+      }
+    });
   }
 
   private calculateBalance(wallets: Wallet[], balance: Balance): boolean {

--- a/src/app/services/wallet/history.service.spec.ts
+++ b/src/app/services/wallet/history.service.spec.ts
@@ -6,8 +6,9 @@ import { BigNumber } from 'bignumber.js';
 import { HistoryService } from './history.service';
 import { WalletService } from './wallet.service';
 import { ApiService } from '../api.service';
-import { MockWalletService } from '../../utils/test-mocks';
+import { MockWalletService, MockGlobalsService } from '../../utils/test-mocks';
 import { createAddress } from './wallet.service.spec';
+import { GlobalsService } from '../globals.service';
 import {
   Address,
   NormalTransaction } from '../../app.datatypes';
@@ -26,6 +27,7 @@ describe('HistoryService', () => {
       providers: [
         HistoryService,
         { provide: WalletService, useClass: MockWalletService },
+        { provide: GlobalsService, useClass: MockGlobalsService },
         {
           provide: ApiService,
           useValue: jasmine.createSpyObj('ApiService', {
@@ -102,7 +104,7 @@ describe('HistoryService', () => {
 
   describe('getAllPendingTransactions', () => {
     it('should get the transactions', fakeAsync(() => {
-      historyService.getAllPendingTransactions();
+      historyService.getAllPendingTransactions().subscribe();
       expect(spyApiService.get).toHaveBeenCalledWith('pendingTxs');
     }));
   });

--- a/src/app/services/wallet/history.service.ts
+++ b/src/app/services/wallet/history.service.ts
@@ -25,7 +25,7 @@ export class HistoryService {
           return Observable.of([]);
         }
 
-        return this.globalsService.nodeVersion.filter(version => version !== null).first().flatMap (version => {
+        return this.globalsService.getValidNodeVersion().flatMap (version => {
           let TxObsv: Observable<any>;
           if (isEqualOrSuperiorVersion(version, '0.25.0')) {
             TxObsv = this.retrieveAddressesTransactions(addresses).map(transactions => {
@@ -124,7 +124,7 @@ export class HistoryService {
   }
 
   getAllPendingTransactions(): Observable<any> {
-    return this.globalsService.nodeVersion.filter(version => version !== null).first().flatMap (version => {
+    return this.globalsService.getValidNodeVersion().flatMap (version => {
       if (isEqualOrSuperiorVersion(version, '0.25.0')) {
         return this.apiService.get('pendingTxs', { verbose: true });
       } else {

--- a/src/app/services/wallet/history.service.ts
+++ b/src/app/services/wallet/history.service.ts
@@ -6,13 +6,16 @@ import { BigNumber } from 'bignumber.js';
 import { ApiService } from '../api.service';
 import { Address, NormalTransaction } from '../../app.datatypes';
 import { WalletService } from './wallet.service';
+import { GlobalsService } from '../globals.service';
+import { isEqualOrSuperiorVersion } from '../../utils/semver';
 
 @Injectable()
 export class HistoryService {
 
   constructor(
     private apiService: ApiService,
-    private walletService: WalletService
+    private walletService: WalletService,
+    private globalsService: GlobalsService
   ) { }
 
   transactions(): Observable<any[]> {
@@ -22,59 +25,71 @@ export class HistoryService {
           return Observable.of([]);
         }
 
-        return Observable.forkJoin(addresses.map(address => this.retrieveAddressTransactions(address)))
-          .map(transactions => {
-            return []
-              .concat.apply([], transactions)
-              .reduce((array, item) => {
-                if (!array.find(trans => trans.txid === item.txid)) {
-                  array.push(item);
+        return this.globalsService.nodeVersion.filter(version => version !== null).first().flatMap (version => {
+          let TxObsv: Observable<any>;
+          if (isEqualOrSuperiorVersion(version, '0.25.0')) {
+            TxObsv = this.retrieveAddressesTransactions(addresses).map(transactions => {
+              return transactions.sort((a, b) =>  b.timestamp - a.timestamp);
+            });
+          } else {
+            TxObsv = Observable.forkJoin(addresses.map(address => this.retrieveAddressTransactions(address)))
+              .map(transactions => {
+                return []
+                  .concat.apply([], transactions)
+                  .reduce((array, item) => {
+                    if (!array.find(trans => trans.txid === item.txid)) {
+                      array.push(item);
+                    }
+
+                    return array;
+                  }, [])
+                  .sort((a, b) =>  b.timestamp - a.timestamp);
+              });
+          }
+
+          return TxObsv.map(transactions => {
+            return transactions.map(transaction => {
+              const outgoing = addresses.some(address => {
+                return transaction.inputs.some(input => input.owner === address.address);
+              });
+
+              const relevantOutputs = transaction.outputs.reduce((array, output) => {
+                const isMyOutput = addresses.some(address => address.address === output.dst);
+
+                if ((outgoing && !isMyOutput) || (!outgoing && isMyOutput)) {
+                  array.push(output);
                 }
 
                 return array;
-              }, [])
-              .sort((a, b) =>  b.timestamp - a.timestamp)
-              .map(transaction => {
-                const outgoing = addresses.some(address => {
-                  return transaction.inputs.some(input => input.owner === address.address);
-                });
+              }, []);
 
-                const relevantOutputs = transaction.outputs.reduce((array, output) => {
-                  const isMyOutput = addresses.some(address => address.address === output.dst);
+              const calculatedOutputs = (outgoing && relevantOutputs.length === 0)
+              || (!outgoing && relevantOutputs.length === transaction.outputs.length)
+                ? transaction.outputs
+                : relevantOutputs;
 
-                  if ((outgoing && !isMyOutput) || (!outgoing && isMyOutput)) {
-                    array.push(output);
-                  }
+              transaction.addresses.push(
+                ...calculatedOutputs
+                  .map(output => output.dst)
+                  .filter((dst, i, self) => self.indexOf(dst) === i),
+              );
 
-                  return array;
-                }, []);
+              calculatedOutputs.map (output => transaction.balance = transaction.balance.plus(new BigNumber(output.coins)));
+              transaction.balance = (outgoing ? transaction.balance.negated() : transaction.balance);
 
-                const calculatedOutputs = (outgoing && relevantOutputs.length === 0)
-                || (!outgoing && relevantOutputs.length === transaction.outputs.length)
-                  ? transaction.outputs
-                  : relevantOutputs;
+              transaction.hoursSent = new BigNumber('0');
+              calculatedOutputs.map(output => transaction.hoursSent = transaction.hoursSent.plus(new BigNumber(output.hours)));
 
-                transaction.addresses.push(
-                  ...calculatedOutputs
-                    .map(output => output.dst)
-                    .filter((dst, i, self) => self.indexOf(dst) === i),
-                );
+              let inputsHours = new BigNumber('0');
+              transaction.inputs.map(input => inputsHours = inputsHours.plus(new BigNumber(input.calculated_hours)));
+              let outputsHours = new BigNumber('0');
+              transaction.outputs.map(output => outputsHours = outputsHours.plus(new BigNumber(output.hours)));
+              transaction.hoursBurned = inputsHours.minus(outputsHours);
 
-                calculatedOutputs.map (output => transaction.balance = transaction.balance.plus(new BigNumber(output.coins)));
-                transaction.balance = (outgoing ? transaction.balance.negated() : transaction.balance);
-
-                transaction.hoursSent = new BigNumber('0');
-                calculatedOutputs.map(output => transaction.hoursSent = transaction.hoursSent.plus(new BigNumber(output.hours)));
-
-                let inputsHours = new BigNumber('0');
-                transaction.inputs.map(input => inputsHours = inputsHours.plus(new BigNumber(input.calculated_hours)));
-                let outputsHours = new BigNumber('0');
-                transaction.outputs.map(output => outputsHours = outputsHours.plus(new BigNumber(output.hours)));
-                transaction.hoursBurned = inputsHours.minus(outputsHours);
-
-                return transaction;
-              });
+              return transaction;
+            });
           });
+        });
       });
   }
 
@@ -92,8 +107,30 @@ export class HistoryService {
       })));
   }
 
+  retrieveAddressesTransactions(addresses: Address[]): Observable<NormalTransaction[]> {
+    const formattedAddresses = addresses.map(a => a.address).join(',');
+
+    return this.apiService.post('transactions', { addrs: formattedAddresses, verbose: true })
+      .map(transactions => transactions.map(transaction => ({
+        addresses: [],
+        balance: new BigNumber('0'),
+        block: transaction.status.block_seq,
+        confirmed: transaction.status.confirmed,
+        timestamp: transaction.txn.timestamp,
+        txid: transaction.txn.txid,
+        inputs: transaction.txn.inputs,
+        outputs: transaction.txn.outputs,
+      })));
+  }
+
   getAllPendingTransactions(): Observable<any> {
-    return this.apiService.get('pendingTxs');
+    return this.globalsService.nodeVersion.filter(version => version !== null).first().flatMap (version => {
+      if (isEqualOrSuperiorVersion(version, '0.25.0')) {
+        return this.apiService.get('pendingTxs', { verbose: true });
+      } else {
+        return this.apiService.get('pendingTxs');
+      }
+    });
   }
 
   getTransactionDetails(uxid: string): Observable<any> {

--- a/src/app/services/wallet/spending.service.spec.ts
+++ b/src/app/services/wallet/spending.service.spec.ts
@@ -9,8 +9,9 @@ import { WalletService } from './wallet.service';
 import { ApiService } from '../api.service';
 import { CipherProvider } from '../cipher.provider';
 import { CoinService } from '../coin.service';
-import { MockCoinService, MockWalletService } from '../../utils/test-mocks';
+import { MockCoinService, MockWalletService, MockGlobalsService } from '../../utils/test-mocks';
 import { createWallet, createAddress } from './wallet.service.spec';
+import { GlobalsService } from '../globals.service';
 import {
   Wallet,
   TransactionOutput,
@@ -48,7 +49,8 @@ describe('SpendingService', () => {
           provide: TranslateService,
           useValue: jasmine.createSpyObj('TranslateService', ['instant'])
         },
-        { provide: CoinService, useClass: MockCoinService }
+        { provide: CoinService, useClass: MockCoinService },
+        { provide: GlobalsService, useClass: MockGlobalsService }
       ]
     });
 

--- a/src/app/services/wallet/spending.service.ts
+++ b/src/app/services/wallet/spending.service.ts
@@ -12,6 +12,8 @@ import { Output, TransactionInput, TransactionOutput,
 import { BaseCoin } from '../../coins/basecoin';
 import { CoinService } from '../coin.service';
 import { WalletService } from './wallet.service';
+import { GlobalsService } from '../globals.service';
+import { isEqualOrSuperiorVersion } from '../../utils/semver';
 
 @Injectable()
 export class SpendingService {
@@ -28,6 +30,7 @@ export class SpendingService {
     private cipherProvider: CipherProvider,
     private translate: TranslateService,
     private walletService: WalletService,
+    private globalsService: GlobalsService,
     coinService: CoinService,
   ) {
     coinService.currentCoin.subscribe((coin) => this.currentCoin = coin);
@@ -132,26 +135,50 @@ export class SpendingService {
   }
 
   private getOutputs(addresses): Observable<Output[]> {
-    return addresses ? this.apiService.get('outputs', { addrs: addresses }).map((response: GetOutputsRequest) => {
-      const outputs: Output[] = [];
-      response.head_outputs.forEach(output => outputs.push({
-        address: output.address,
-        coins: new BigNumber(output.coins),
-        hash: output.hash,
-        calculated_hours: new BigNumber(output.calculated_hours)
-      }));
-      return outputs;
-    }) : Observable.of([]);
+    if (!addresses) {
+      return Observable.of([]);
+    } else {
+      return this.globalsService.nodeVersion.filter(version => version !== null).first().flatMap (version => {
+        let outputsRequest: Observable<any>;
+        if (isEqualOrSuperiorVersion(version, '0.25.0')) {
+          outputsRequest = this.apiService.post('outputs', { addrs: addresses });
+        } else {
+          outputsRequest = this.apiService.get('outputs', { addrs: addresses });
+        }
+
+        return outputsRequest.map((response: GetOutputsRequest) => {
+          const outputs: Output[] = [];
+          response.head_outputs.forEach(output => outputs.push({
+            address: output.address,
+            coins: new BigNumber(output.coins),
+            hash: output.hash,
+            calculated_hours: new BigNumber(output.calculated_hours)
+          }));
+          return outputs;
+        });
+      });
+    }
   }
 
   private getRequestOutputs(addresses): Observable<GetOutputsRequestOutput[]> {
-    return addresses
-      ? this.apiService.get('outputs', { addrs: addresses }).map(response => response.head_outputs)
-      : Observable.of([]);
+    if (!addresses) {
+      return Observable.of([]);
+    } else {
+      return this.globalsService.nodeVersion.filter(version => version !== null).first().flatMap (version => {
+        let outputsRequest: Observable<any>;
+        if (isEqualOrSuperiorVersion(version, '0.25.0')) {
+          outputsRequest = this.apiService.post('outputs', { addrs: addresses });
+        } else {
+          outputsRequest = this.apiService.get('outputs', { addrs: addresses });
+        }
+
+        return outputsRequest.map(response => response.head_outputs as GetOutputsRequestOutput[]);
+      });
+    }
   }
 
   private postTransaction(rawTransaction: string): Observable<string> {
-    return this.apiService.post('injectTransaction', { rawtx: rawTransaction });
+    return this.apiService.post('injectTransaction', { rawtx: rawTransaction }, { json: true });
   }
 
   private generateRawTransaction(txInputs: TransactionInput[], txOutputs: TransactionOutput[]): Observable<string> {

--- a/src/app/services/wallet/spending.service.ts
+++ b/src/app/services/wallet/spending.service.ts
@@ -138,7 +138,7 @@ export class SpendingService {
     if (!addresses) {
       return Observable.of([]);
     } else {
-      return this.globalsService.nodeVersion.filter(version => version !== null).first().flatMap (version => {
+      return this.globalsService.getValidNodeVersion().flatMap (version => {
         let outputsRequest: Observable<any>;
         if (isEqualOrSuperiorVersion(version, '0.25.0')) {
           outputsRequest = this.apiService.post('outputs', { addrs: addresses });
@@ -164,7 +164,7 @@ export class SpendingService {
     if (!addresses) {
       return Observable.of([]);
     } else {
-      return this.globalsService.nodeVersion.filter(version => version !== null).first().flatMap (version => {
+      return this.globalsService.getValidNodeVersion().flatMap (version => {
         let outputsRequest: Observable<any>;
         if (isEqualOrSuperiorVersion(version, '0.25.0')) {
           outputsRequest = this.apiService.post('outputs', { addrs: addresses });

--- a/src/app/services/wallet/wallet.service.cipher.spec.ts
+++ b/src/app/services/wallet/wallet.service.cipher.spec.ts
@@ -9,8 +9,9 @@ import { ApiService } from '../api.service';
 import { CipherProvider } from '../cipher.provider';
 import { Wallet, Address, TransactionOutput, TransactionInput, Output, Balance } from '../../app.datatypes';
 import { CoinService } from '../coin.service';
-import { MockCoinService } from '../../utils/test-mocks';
+import { MockCoinService, MockGlobalsService } from '../../utils/test-mocks';
 import { createWallet } from './wallet.service.spec';
+import { GlobalsService } from '../globals.service';
 
 describe('WalletService with cipher:', () => {
   let store = {};
@@ -40,7 +41,8 @@ describe('WalletService with cipher:', () => {
           provide: TranslateService,
           useValue: jasmine.createSpyObj('TranslateService', ['instant'])
         },
-        { provide: CoinService, useClass: MockCoinService }
+        { provide: CoinService, useClass: MockCoinService },
+        { provide: GlobalsService, useClass: MockGlobalsService }
       ]
     });
 

--- a/src/app/services/wallet/wallet.service.spec.ts
+++ b/src/app/services/wallet/wallet.service.spec.ts
@@ -9,8 +9,9 @@ import { WalletService } from './wallet.service';
 import { CipherProvider } from '../cipher.provider';
 import { CoinService } from '../coin.service';
 import { EventEmitter } from '@angular/core';
-import { MockCoinService } from '../../utils/test-mocks';
+import { MockCoinService, MockGlobalsService } from '../../utils/test-mocks';
 import { ApiService } from '../api.service';
+import { GlobalsService } from '../globals.service';
 import {
   Wallet,
   Address } from '../../app.datatypes';
@@ -42,7 +43,8 @@ describe('WalletService', () => {
             'get': Observable.of([])
           })
         },
-        { provide: CoinService, useClass: MockCoinService }
+        { provide: CoinService, useClass: MockCoinService },
+        { provide: GlobalsService, useClass: MockGlobalsService }
       ]
     });
 

--- a/src/app/services/wallet/wallet.service.ts
+++ b/src/app/services/wallet/wallet.service.ts
@@ -176,7 +176,7 @@ export class WalletService {
     const maxAdrressesToScan = environment.e2eTest ? 2 : 100;
 
     return this.addAddress(wallet, false)
-      .flatMap(() => this.apiService.get('explorer/address', { address: wallet.addresses[wallet.addresses.length - 1].address }))
+      .flatMap(() => this.apiService.get('transactions', { addrs: wallet.addresses[wallet.addresses.length - 1].address }))
       .flatMap(transactions => {
         if (transactions && transactions.length > 0) {
           lastIndexWithTxs = wallet.addresses.length - 1;

--- a/src/app/utils/semver.spec.ts
+++ b/src/app/utils/semver.spec.ts
@@ -4,14 +4,11 @@ describe('semver', () => {
   it('correctly compares versions', () => {
     expect(isEqualOrSuperiorVersion('0.23.0', '0.22.0')).toBeTruthy();
     expect(isEqualOrSuperiorVersion('0.23.0', '0.23.0')).toBeTruthy();
-    expect(isEqualOrSuperiorVersion('0.23.0', '0.23.1')).toBeFalsy();
+    expect(isEqualOrSuperiorVersion('0.23.0', '0.23.1')).toBeTruthy();
     expect(isEqualOrSuperiorVersion('0.23.1', '0.24.0')).toBeFalsy();
     expect(isEqualOrSuperiorVersion('0.24.0', '1.0.0')).toBeFalsy();
-  });
-
-  it('correctly handles rc versions', () => {
-    expect(isEqualOrSuperiorVersion('0.23.1-rc.1', '0.23.0')).toBeTruthy();
-    expect(isEqualOrSuperiorVersion('0.23.1-rc.1', '0.23.1')).toBeTruthy();
-    expect(isEqualOrSuperiorVersion('0.23.1-rc.1', '0.23.2')).toBeFalsy();
+    expect(isEqualOrSuperiorVersion('0.24', '0.23')).toBeTruthy();
+    expect(isEqualOrSuperiorVersion('0.24', '0.24')).toBeTruthy();
+    expect(isEqualOrSuperiorVersion('0.24', '0.25')).toBeFalsy();
   });
 });

--- a/src/app/utils/semver.spec.ts
+++ b/src/app/utils/semver.spec.ts
@@ -1,0 +1,17 @@
+import { isEqualOrSuperiorVersion } from './semver';
+
+describe('semver', () => {
+  it('correctly compares versions', () => {
+    expect(isEqualOrSuperiorVersion('0.23.0', '0.22.0')).toBeTruthy();
+    expect(isEqualOrSuperiorVersion('0.23.0', '0.23.0')).toBeTruthy();
+    expect(isEqualOrSuperiorVersion('0.23.0', '0.23.1')).toBeFalsy();
+    expect(isEqualOrSuperiorVersion('0.23.1', '0.24.0')).toBeFalsy();
+    expect(isEqualOrSuperiorVersion('0.24.0', '1.0.0')).toBeFalsy();
+  });
+
+  it('correctly handles rc versions', () => {
+    expect(isEqualOrSuperiorVersion('0.23.1-rc.1', '0.23.0')).toBeTruthy();
+    expect(isEqualOrSuperiorVersion('0.23.1-rc.1', '0.23.1')).toBeTruthy();
+    expect(isEqualOrSuperiorVersion('0.23.1-rc.1', '0.23.2')).toBeFalsy();
+  });
+});

--- a/src/app/utils/semver.ts
+++ b/src/app/utils/semver.ts
@@ -1,16 +1,16 @@
 /**
- * Return true is current is equal or superior to target. The -rc parts are ignored.
+ * Return true is current is equal or superior to target. Versions normally are composed of 3 parts,
+ * separated by points, but this function only takes into account the first two parts, so 0.24.0 is
+ * considered equal to 0.24.1.
  */
 export function isEqualOrSuperiorVersion(current: string, target: string): boolean {
   const currentParts = current.split('.');
-  if (currentParts.length < 3) { return false; }
-  currentParts[2] = currentParts[2].split('-')[0];
+  if (currentParts.length < 2) { return false; }
 
   const targetParts = target.split('.');
-  if (targetParts.length < 3) { return false; }
-  targetParts[2] = targetParts[2].split('-')[0];
+  if (targetParts.length < 2) { return false; }
 
-  for (let i = 0; i < 3; i++) {
+  for (let i = 0; i < 2; i++) {
     const currentNumber = Number(currentParts[i]);
     const targetNumber = Number(targetParts[i]);
 

--- a/src/app/utils/semver.ts
+++ b/src/app/utils/semver.ts
@@ -1,0 +1,27 @@
+/**
+ * Return true is current is equal or superior to target. The -rc parts are ignored.
+ */
+export function isEqualOrSuperiorVersion(current: string, target: string): boolean {
+  const currentParts = current.split('.');
+  if (currentParts.length < 3) { return false; }
+  currentParts[2] = currentParts[2].split('-')[0];
+
+  const targetParts = target.split('.');
+  if (targetParts.length < 3) { return false; }
+  targetParts[2] = targetParts[2].split('-')[0];
+
+  for (let i = 0; i < 3; i++) {
+    const currentNumber = Number(currentParts[i]);
+    const targetNumber = Number(targetParts[i]);
+
+    if (currentNumber > targetNumber) {
+      return true;
+    }
+
+    if (currentNumber < targetNumber) {
+      return false;
+    }
+  }
+
+  return true;
+}

--- a/src/app/utils/test-mocks.ts
+++ b/src/app/utils/test-mocks.ts
@@ -50,6 +50,10 @@ export class MockNavBarService {
   setActiveComponent() {}
 }
 
+export class MockGlobalsService {
+  nodeVersion = new BehaviorSubject<string>('0.24.0');
+}
+
 export class MockPurchaseService {
   all(): Observable<any[]> {
     return Observable.of([]);

--- a/src/app/utils/test-mocks.ts
+++ b/src/app/utils/test-mocks.ts
@@ -51,7 +51,15 @@ export class MockNavBarService {
 }
 
 export class MockGlobalsService {
-  nodeVersion = new BehaviorSubject<string>('0.24.0');
+  private nodeVersion = new BehaviorSubject<string>('0.24.0');
+
+  setNodeVersion(version: string) {
+    this.nodeVersion.next(version);
+  }
+
+  getValidNodeVersion(): Observable<string> {
+    return this.nodeVersion.filter(version => version !== null).first();
+  }
 }
 
 export class MockPurchaseService {


### PR DESCRIPTION
Fixes #160 

Changes:
- The connections to the node now use many of the improvements added in v0.25.0, Mainly the `verbose` argument and the ability to send long lists of addresses using POST.
- A way to determine the version of the node was created. This is currently used to maintain compatibility with the version 0.24.0 of the node and to use the new features only if the node is runnin v0.25.0 or higher. 
- The function responsible for sending POST requests was updated, to be able to send more than Json.
- The unit tests were updated to be compatible with the changes.