### PR TITLE
Validate the correct number of decimals

### DIFF
--- a/src/app/components/pages/send-skycoin/send-form/send-form.component.spec.ts
+++ b/src/app/components/pages/send-skycoin/send-form/send-form.component.spec.ts
@@ -7,7 +7,8 @@ import { SendFormComponent } from './send-form.component';
 import { WalletService } from '../../../../services/wallet/wallet.service';
 import { SpendingService } from '../../../../services/wallet/spending.service';
 import { CoinService } from '../../../../services/coin.service';
-import { MockTranslatePipe, MockWalletService, MockSpendingService, MockMatSnackBar, MockCoinService } from '../../../../utils/test-mocks';
+import { BlockchainService } from '../../../../services/blockchain.service';
+import { MockTranslatePipe, MockWalletService, MockSpendingService, MockMatSnackBar, MockCoinService, MockBlockchainService } from '../../../../utils/test-mocks';
 
 describe('SendFormComponent', () => {
   let component: SendFormComponent;
@@ -23,7 +24,8 @@ describe('SendFormComponent', () => {
         { provide: WalletService, useClass: MockWalletService },
         { provide: SpendingService, useClass: MockSpendingService },
         { provide: MatDialog, useClass: MockMatSnackBar },
-        { provide: CoinService, useClass: MockCoinService }
+        { provide: CoinService, useClass: MockCoinService },
+        { provide: BlockchainService, useClass: MockBlockchainService }
       ]
     }).compileComponents();
   }));

--- a/src/app/components/pages/send-skycoin/send-form/send-form.component.ts
+++ b/src/app/components/pages/send-skycoin/send-form/send-form.component.ts
@@ -52,8 +52,6 @@ export class SendFormComponent implements OnInit, OnDestroy {
     this.subscription.add(this.coinService.currentCoin
       .subscribe((coin: BaseCoin) => this.currentCoin = coin)
     );
-
-    window['blockchainService'] = this.blockchainService;
   }
 
   ngOnDestroy() {
@@ -63,8 +61,6 @@ export class SendFormComponent implements OnInit, OnDestroy {
     if (this.unlockSubscription) {
       this.unlockSubscription.unsubscribe();
     }
-
-    delete window['blockchainService'];
   }
 
   onVerify(event = null) {
@@ -133,7 +129,7 @@ export class SendFormComponent implements OnInit, OnDestroy {
         Validators.required,
         Validators.min(0.000001),
         Validators.max(balance),
-        this.validateAmount,
+        this.validateAmount.bind(this),
       ]);
 
       this.form.controls.amount.updateValueAndValidity();
@@ -153,7 +149,7 @@ export class SendFormComponent implements OnInit, OnDestroy {
 
     const parts = amountControl.value.toString().split('.');
 
-    if (parts.length === 2 && parts[1].length > window['blockchainService'].currentMaxDecimals) {
+    if (parts.length === 2 && parts[1].length > this.blockchainService.currentMaxDecimals) {
       return { Invalid: true };
     }
 

--- a/src/app/components/pages/send-skycoin/send-form/send-form.component.ts
+++ b/src/app/components/pages/send-skycoin/send-form/send-form.component.ts
@@ -13,6 +13,7 @@ import { Wallet } from '../../../../app.datatypes';
 import { openUnlockWalletModal } from '../../../../utils/index';
 import { BaseCoin } from '../../../../coins/basecoin';
 import { CoinService } from '../../../../services/coin.service';
+import { BlockchainService } from '../../../../services/blockchain.service';
 
 @Component({
   selector: 'app-send-form',
@@ -37,7 +38,8 @@ export class SendFormComponent implements OnInit, OnDestroy {
     private spendingService: SpendingService,
     private snackbar: MatSnackBar,
     private unlockDialog: MatDialog,
-    private coinService: CoinService
+    private coinService: CoinService,
+    private blockchainService: BlockchainService
   ) {}
 
   ngOnInit() {
@@ -50,6 +52,8 @@ export class SendFormComponent implements OnInit, OnDestroy {
     this.subscription.add(this.coinService.currentCoin
       .subscribe((coin: BaseCoin) => this.currentCoin = coin)
     );
+
+    window['blockchainService'] = this.blockchainService;
   }
 
   ngOnDestroy() {
@@ -59,6 +63,8 @@ export class SendFormComponent implements OnInit, OnDestroy {
     if (this.unlockSubscription) {
       this.unlockSubscription.unsubscribe();
     }
+
+    delete window['blockchainService'];
   }
 
   onVerify(event = null) {
@@ -147,7 +153,7 @@ export class SendFormComponent implements OnInit, OnDestroy {
 
     const parts = amountControl.value.toString().split('.');
 
-    if (parts.length === 2 && parts[1].length > 6) {
+    if (parts.length === 2 && parts[1].length > window['blockchainService'].currentMaxDecimals) {
       return { Invalid: true };
     }
 

--- a/src/app/services/blockchain.service.ts
+++ b/src/app/services/blockchain.service.ts
@@ -29,11 +29,16 @@ export class ProgressEvent {
 export class BlockchainService {
   private progressSubject: BehaviorSubject<ProgressEvent> = new BehaviorSubject<ProgressEvent>(null);
   private connectionsSubscription: Subscription;
+  private maxDecimals = 6;
   private readonly defaultPeriod = 90000;
   private readonly shortPeriod = 5000;
 
   get progress(): Observable<ProgressEvent> {
     return this.progressSubject.asObservable();
+  }
+
+  get currentMaxDecimals(): number {
+    return this.maxDecimals;
   }
 
   constructor (
@@ -115,7 +120,10 @@ export class BlockchainService {
           throw { reported: true };
         }
       })
-      .flatMap(() => this.apiService.get('version'))
-      .map ((response: any) => this.globalsService.setNodeVersion(response.version));
+      .flatMap(() => this.apiService.get('health'))
+      .map ((response: any) => {
+        this.globalsService.setNodeVersion(response.version.version);
+        this.maxDecimals = response.user_verify_transaction.max_decimals;
+      });
   }
 }

--- a/src/app/utils/test-mocks.ts
+++ b/src/app/utils/test-mocks.ts
@@ -147,6 +147,10 @@ export class MockBlockchainService {
     return Observable.of();
   }
 
+  get currentMaxDecimals() {
+    return 3;
+  }
+
   lastBlock(): Observable<any> {
     return Observable.of({});
   }


### PR DESCRIPTION
Changes:
-  The form for sending coins no longer checks if the number of coins has 6 or fewer decimal places, but validates if the number of decimal places is not greater than the amount currently activated in the node. The number of valid decimal places is obtained with a call to the `health` api endpoint