### PR TITLE
Request the seed before being able to see the addresses

### DIFF
--- a/e2e/wallets.po.ts
+++ b/e2e/wallets.po.ts
@@ -89,7 +89,7 @@ export class WalletsPage {
       btnCreate.click();
       this.waitUntilLoading();
 
-      return this.getWalletAddress().then((address) => {
+      return this.getWalletAddress('skycoin-web-e2e-test-create-wallet-seed').then((address) => {
         return address === '2KLc8ha9uAzSLsytwsAKo8avjmVXyyvTH7e';
       });
     });
@@ -122,7 +122,7 @@ export class WalletsPage {
       btnLoad.click();
       this.waitUntilLoading();
 
-      return this.getWalletAddress().then((address) => {
+      return this.getWalletAddress('skycoin-web-e2e-test-load-wallet-seed').then((address) => {
         return address === 'quS3czcXyeqSAhrza7df643P4yGS8PNPap';
       });
     });
@@ -307,16 +307,32 @@ export class WalletsPage {
     }
   }
 
-  private getWalletAddress() {
+  private getWalletAddress(seed: string) {
     const walletElement = element.all(by.css('.-wallet')).last();
 
     return walletElement.click().then(() => {
-      const recordElement = element.all(by.css('app-wallet-detail')).last().element(by.css('.-record'));
-      return recordElement.isPresent().then((status) => {
+      const seedField = element(by.css('[formcontrolname="seed"]'));
+      return seedField.isPresent().then((status) => {
         if (status) {
-          return recordElement.element(by.css('.address-column')).getText().then(txt => txt);
+          seedField.clear();
+          seedField.sendKeys(seed + '?');
+
+          const btnUnlock = element(by.buttonText('Unlock'));
+          btnUnlock.click();
+          this.waitUntilLoading();
         }
+
+        return this.finishGettingWalletAddress();
       });
+    });
+  }
+
+  private finishGettingWalletAddress() {
+    const recordElement = element.all(by.css('app-wallet-detail')).last().element(by.css('.-record'));
+    return recordElement.isPresent().then((status) => {
+      if (status) {
+        return recordElement.element(by.css('.address-column')).getText().then(txt => txt);
+      }
     });
   }
 }

--- a/src/app/app.datatypes.ts
+++ b/src/app/app.datatypes.ts
@@ -4,6 +4,7 @@ export interface Wallet {
   label: string;
   addresses: Address[];
   seed?: string;
+  needSeedConfirmation?: boolean;
   balance?: BigNumber;
   hours?: BigNumber;
   hidden?: boolean;

--- a/src/app/components/pages/onboarding/onboarding-create-wallet/onboarding-create-wallet.component.ts
+++ b/src/app/components/pages/onboarding/onboarding-create-wallet/onboarding-create-wallet.component.ts
@@ -144,6 +144,7 @@ export class OnboardingCreateWalletComponent implements OnInit, OnDestroy {
       this.coinService.changeCoin(initialCoin);
       this.onCreateError(response.message ? response.message : response.toString());
     } else {
+      wallet.needSeedConfirmation = false;
       this.walletService.add(wallet);
       this.finish();
     }

--- a/src/app/components/pages/send-skycoin/send-form/send-form.component.ts
+++ b/src/app/components/pages/send-skycoin/send-form/send-form.component.ts
@@ -81,7 +81,7 @@ export class SendFormComponent implements OnInit, OnDestroy {
       }
 
       this.unlockSubscription = openUnlockWalletModal(wallet, this.unlockDialog).componentInstance
-        .onWalletUnlocked.subscribe(() => this.createTransaction(wallet));
+        .onWalletUnlocked.first().subscribe(() => this.createTransaction(wallet));
     } else {
       this.createTransaction(wallet);
     }

--- a/src/app/components/pages/wallets/create-wallet/create-wallet.component.ts
+++ b/src/app/components/pages/wallets/create-wallet/create-wallet.component.ts
@@ -74,6 +74,7 @@ export class CreateWalletComponent implements OnDestroy {
       this.coinService.changeCoin(initialCoin);
       this.onCreateError(response.message ? response.message : response.toString());
     } else {
+      wallet.needSeedConfirmation = false;
       this.walletService.add(wallet);
       this.finish();
     }

--- a/src/app/components/pages/wallets/unlock-wallet/unlock-wallet.component.html
+++ b/src/app/components/pages/wallets/unlock-wallet/unlock-wallet.component.html
@@ -3,7 +3,7 @@
            [disableDismiss]="disableDismiss"
            [loadingProgress]="loadingProgress">
 
-  <div *ngIf="showComfirmSeedWarning" class="alert-box">
+  <div *ngIf="showConfirmSeedWarning" class="alert-box">
     <div class="title">{{ 'wallet.unlock.confirmation-warning-title' | translate }}</div>
     <div>{{ 'wallet.unlock.confirmation-warning-text1' | translate }}</div>
     <br />
@@ -19,7 +19,7 @@
       <textarea formControlName="seed" id="seed" row="2"></textarea>
     </div>
   </div>
-  <div *ngIf="showComfirmSeedWarning">
+  <div *ngIf="showConfirmSeedWarning">
     <div>{{ 'wallet.unlock.confirmation-warning-text3' | translate }}</div>
   </div>
   <div class="-buttons">

--- a/src/app/components/pages/wallets/unlock-wallet/unlock-wallet.component.html
+++ b/src/app/components/pages/wallets/unlock-wallet/unlock-wallet.component.html
@@ -2,11 +2,25 @@
            [dialog]="dialogRef"
            [disableDismiss]="disableDismiss"
            [loadingProgress]="loadingProgress">
+
+  <div *ngIf="showComfirmSeedWarning" class="alert-box">
+    <div class="title">{{ 'wallet.unlock.confirmation-warning-title' | translate }}</div>
+    <div>{{ 'wallet.unlock.confirmation-warning-text1' | translate }}</div>
+    <br />
+    <div>
+      {{ 'wallet.unlock.confirmation-warning-text2-1' | translate }}
+      <span class="link" (click)="delete()">{{ 'wallet.unlock.confirmation-warning-text2-2' | translate }}</span>
+    </div>
+  </div>
+
   <div [formGroup]="form">
     <div class="form-field">
       <label for="seed">{{ 'wallet.unlock.seed' | translate }}</label>
       <textarea formControlName="seed" id="seed" row="2"></textarea>
     </div>
+  </div>
+  <div *ngIf="showComfirmSeedWarning">
+    <div>{{ 'wallet.unlock.confirmation-warning-text3' | translate }}</div>
   </div>
   <div class="-buttons">
     <app-button (action)="closePopup()" [disabled]="disableDismiss">

--- a/src/app/components/pages/wallets/unlock-wallet/unlock-wallet.component.scss
+++ b/src/app/components/pages/wallets/unlock-wallet/unlock-wallet.component.scss
@@ -1,0 +1,12 @@
+@import '../../../../../theme/_variables.scss';
+
+.alert-box {
+  margin-bottom: 20px;
+
+  .title {
+    font-size: 19px;
+    margin-bottom: 10px;
+    color: $red;
+    line-height: 1.3;
+  }
+}

--- a/src/app/components/pages/wallets/unlock-wallet/unlock-wallet.component.ts
+++ b/src/app/components/pages/wallets/unlock-wallet/unlock-wallet.component.ts
@@ -7,7 +7,7 @@ import { ISubscription } from 'rxjs/Subscription';
 import { Wallet } from '../../../../app.datatypes';
 import { WalletService } from '../../../../services/wallet/wallet.service';
 
-export class ComfirmSeedParams {
+export class ConfirmSeedParams {
   wallet: Wallet;
 }
 
@@ -23,7 +23,7 @@ export class UnlockWalletComponent implements OnInit, OnDestroy {
   form: FormGroup;
   disableDismiss = false;
   loadingProgress = 0;
-  showComfirmSeedWarning;
+  showConfirmSeedWarning;
 
   private wallet: Wallet;
   private unlockSubscription: ISubscription;
@@ -37,10 +37,10 @@ export class UnlockWalletComponent implements OnInit, OnDestroy {
     private snackbar: MatSnackBar
   ) {
     if (data.wallet) {
-      this.showComfirmSeedWarning = true;
+      this.showConfirmSeedWarning = true;
       this.wallet = data.wallet;
     } else {
-      this.showComfirmSeedWarning = false;
+      this.showConfirmSeedWarning = false;
       this.wallet = data;
     }
   }
@@ -69,7 +69,7 @@ export class UnlockWalletComponent implements OnInit, OnDestroy {
       this.progressSubscription = onProgressChanged.subscribe((progress) => this.loadingProgress = progress);
     }
 
-    const seed = !this.showComfirmSeedWarning ?
+    const seed = !this.showConfirmSeedWarning ?
       this.form.value.seed :
       (this.form.value.seed as string).substr(0, (this.form.value.seed as string).length - 1);
 
@@ -90,7 +90,7 @@ export class UnlockWalletComponent implements OnInit, OnDestroy {
       seed: ['', Validators.required],
     });
 
-    if (this.showComfirmSeedWarning) {
+    if (this.showConfirmSeedWarning) {
       this.form.controls.seed.setValidators([
         Validators.required,
         this.validateSeedConfirmation,

--- a/src/app/components/pages/wallets/wallets.component.html
+++ b/src/app/components/pages/wallets/wallets.component.html
@@ -15,8 +15,14 @@
             <div class="-wallet" (click)="toggleWallet(wallet)">
               <div class="-width-250 -label" [attr.title]="wallet.label">{{ wallet.label }}</div>
               <div class="flex-fill -encryption">
-                <img src="../../../../assets/img/lock-gold.png" class="-lock" (click)="unlockWallet($event, wallet)" *ngIf="!wallet.seed">
-                <img src="../../../../assets/img/unlock-grey.png" *ngIf="wallet.seed">
+                <img src="../../../../assets/img/lock-gold.png"
+                  class="-lock"
+                  (click)="unlockWallet($event, wallet)"
+                  *ngIf="!wallet.seed || wallet.needSeedConfirmation"
+                  [matTooltip]="'wallet.locked-tooltip' | translate">
+                <img src="../../../../assets/img/unlock-grey.png"
+                  *ngIf="wallet.seed && !wallet.needSeedConfirmation"
+                  [matTooltip]="'wallet.unlocked-tooltip' | translate">
               </div>
               <div class="-width-130 -coins">{{ (wallet.balance ? wallet.balance.decimalPlaces(6).toString() : 0) | number:'1.0-6' }}</div>
               <div class="-width-130 -hours">{{ (wallet.hours ? wallet.hours.decimalPlaces(0).toString() : 0) | number:'1.0-0' }}</div>

--- a/src/app/components/pages/wallets/wallets.component.spec.ts
+++ b/src/app/components/pages/wallets/wallets.component.spec.ts
@@ -1,11 +1,12 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { NO_ERRORS_SCHEMA } from '@angular/core';
 import { MatDialog } from '@angular/material';
+import { TranslateService } from '@ngx-translate/core';
 
 import { WalletsComponent } from './wallets.component';
 import { WalletService } from '../../../services/wallet/wallet.service';
 import { CoinService } from '../../../services/coin.service';
-import { MockTranslatePipe, MockCoinService, MockWalletService } from '../../../utils/test-mocks';
+import { MockTranslatePipe, MockCoinService, MockWalletService, MockTranslateService } from '../../../utils/test-mocks';
 
 describe('WalletsComponent', () => {
   let component: WalletsComponent;
@@ -18,7 +19,8 @@ describe('WalletsComponent', () => {
       providers: [
         { provide: WalletService, useClass: MockWalletService },
         { provide: MatDialog, useValue: {} },
-        { provide: CoinService, useClass: MockCoinService }
+        { provide: CoinService, useClass: MockCoinService },
+        { provide: TranslateService, useClass: MockTranslateService }
       ]
     })
     .compileComponents();

--- a/src/app/components/pages/wallets/wallets.component.ts
+++ b/src/app/components/pages/wallets/wallets.component.ts
@@ -64,15 +64,15 @@ export class WalletsComponent implements OnInit, OnDestroy {
     if (wallet.needSeedConfirmation) {
       this.removeConfirmationSuscriptions();
 
-      const unlogDialog = openUnlockWalletModal({wallet: wallet}, this.dialog).componentInstance;
+      const unlockDialog = openUnlockWalletModal({wallet: wallet}, this.dialog).componentInstance;
 
-      this.confirmSeedSubscription = unlogDialog.onWalletUnlocked.first().subscribe(() => {
+      this.confirmSeedSubscription = unlockDialog.onWalletUnlocked.first().subscribe(() => {
         wallet.needSeedConfirmation = false;
         this.walletService.saveWallets();
         wallet.opened ? wallet.opened = false : wallet.opened = true;
       });
 
-      this.confirmSeedSubscription = unlogDialog.onDeleteClicked.first().subscribe(() => {
+      this.deleteWalletSubscription = unlockDialog.onDeleteClicked.first().subscribe(() => {
         openDeleteWalletModal(this.dialog, wallet, this.translateService, this.walletService);
       });
     } else {

--- a/src/app/components/pages/wallets/wallets.component.ts
+++ b/src/app/components/pages/wallets/wallets.component.ts
@@ -1,11 +1,12 @@
 import { Component, OnInit, OnDestroy } from '@angular/core';
 import { MatDialog, MatDialogConfig } from '@angular/material/dialog';
 import { Subscription } from 'rxjs/Subscription';
+import { TranslateService } from '@ngx-translate/core';
 
 import { Wallet } from '../../../app.datatypes';
 import { WalletService } from '../../../services/wallet/wallet.service';
 import { CreateWalletComponent } from './create-wallet/create-wallet.component';
-import { openUnlockWalletModal } from '../../../utils/index';
+import { openUnlockWalletModal, openDeleteWalletModal } from '../../../utils/index';
 import { CoinService } from '../../../services/coin.service';
 import { BaseCoin } from '../../../coins/basecoin';
 
@@ -20,11 +21,14 @@ export class WalletsComponent implements OnInit, OnDestroy {
   currentCoin: BaseCoin;
 
   private subscription: Subscription;
+  private confirmSeedSubscription: Subscription;
+  private deleteWalletSubscription: Subscription;
 
   constructor(
     private walletService: WalletService,
     private dialog: MatDialog,
-    private coinService: CoinService
+    private coinService: CoinService,
+    private translateService: TranslateService
   ) {}
 
   ngOnInit() {
@@ -39,6 +43,7 @@ export class WalletsComponent implements OnInit, OnDestroy {
 
   ngOnDestroy() {
     this.subscription.unsubscribe();
+    this.removeConfirmationSuscriptions();
   }
 
   addWallet(create: boolean) {
@@ -49,12 +54,38 @@ export class WalletsComponent implements OnInit, OnDestroy {
   }
 
   unlockWallet(event, wallet: Wallet) {
-    event.stopPropagation();
-
-    openUnlockWalletModal(wallet, this.dialog);
+    if (!wallet.needSeedConfirmation) {
+      event.stopPropagation();
+      openUnlockWalletModal(wallet, this.dialog);
+    }
   }
 
   toggleWallet(wallet: Wallet) {
-    wallet.opened ? wallet.opened = false : wallet.opened = true;
+    if (wallet.needSeedConfirmation) {
+      this.removeConfirmationSuscriptions();
+
+      const unlogDialog = openUnlockWalletModal({wallet: wallet}, this.dialog).componentInstance;
+
+      this.confirmSeedSubscription = unlogDialog.onWalletUnlocked.first().subscribe(() => {
+        wallet.needSeedConfirmation = false;
+        this.walletService.saveWallets();
+        wallet.opened ? wallet.opened = false : wallet.opened = true;
+      });
+
+      this.confirmSeedSubscription = unlogDialog.onDeleteClicked.first().subscribe(() => {
+        openDeleteWalletModal(this.dialog, wallet, this.translateService, this.walletService);
+      });
+    } else {
+      wallet.opened ? wallet.opened = false : wallet.opened = true;
+    }
+  }
+
+  private removeConfirmationSuscriptions() {
+    if (this.confirmSeedSubscription) {
+      this.confirmSeedSubscription.unsubscribe();
+    }
+    if (this.deleteWalletSubscription) {
+      this.deleteWalletSubscription.unsubscribe();
+    }
   }
 }

--- a/src/app/services/wallet/wallet.service.spec.ts
+++ b/src/app/services/wallet/wallet.service.spec.ts
@@ -96,6 +96,7 @@ describe('WalletService', () => {
       const expectedWallet = {
         label: walletLabel,
         seed: walletSeed,
+        needSeedConfirmation: true,
         balance: new BigNumber(0),
         hours: new BigNumber(0),
         addresses: [walletAddress],
@@ -149,6 +150,7 @@ export function createWallet(label: string = 'label', seed: string = 'seed', bal
   return {
     label: label,
     seed: seed,
+    needSeedConfirmation: true,
     balance: balance,
     hours: new BigNumber(0),
     addresses: [

--- a/src/app/services/wallet/wallet.service.ts
+++ b/src/app/services/wallet/wallet.service.ts
@@ -74,6 +74,7 @@ export class WalletService {
         const wallet = {
           label: label,
           seed: seed,
+          needSeedConfirmation: true,
           balance: new BigNumber('0'),
           hours: new BigNumber('0'),
           addresses: [fullAddress],
@@ -148,7 +149,7 @@ export class WalletService {
     this.wallets.value.forEach(wallet => {
       const strippedAddresses: Address[] = [];
       wallet.addresses.forEach(address => strippedAddresses.push({ address: address.address }));
-      strippedWallets.push({ coinId: wallet.coinId, label: wallet.label, addresses: strippedAddresses });
+      strippedWallets.push({ coinId: wallet.coinId, needSeedConfirmation: wallet.needSeedConfirmation, label: wallet.label, addresses: strippedAddresses });
     });
     localStorage.setItem('wallets', JSON.stringify(strippedWallets));
     this.wallets.next(this.wallets.value);

--- a/src/app/utils/index.ts
+++ b/src/app/utils/index.ts
@@ -5,15 +5,16 @@ import { Observable } from 'rxjs/Observable';
 import { TranslateService } from '@ngx-translate/core';
 
 import { Wallet, ConfirmationData } from '../app.datatypes';
-import { UnlockWalletComponent } from '../components/pages/wallets/unlock-wallet/unlock-wallet.component';
+import { UnlockWalletComponent, ComfirmSeedParams } from '../components/pages/wallets/unlock-wallet/unlock-wallet.component';
 import { SelectCoinOverlayComponent } from '../components/layout/select-coin-overlay/select-coin-overlay.component';
 import { SelectLanguageComponent } from '../components/layout/select-language/select-language.component';
 import { QrCodeComponent } from '../components/layout/qr-code/qr-code.component';
 import { ConfirmationComponent } from '../components/layout/confirmation/confirmation.component';
 import { BlockchainService, ProgressStates } from '../services/blockchain.service';
 import { ScanAddressesComponent } from '../components/pages/wallets/scan-addresses/scan-addresses.component';
+import { WalletService } from '../services/wallet/wallet.service';
 
-export function openUnlockWalletModal (wallet: Wallet, unlockDialog: MatDialog): MatDialogRef<UnlockWalletComponent, any> {
+export function openUnlockWalletModal (wallet: Wallet | ComfirmSeedParams, unlockDialog: MatDialog): MatDialogRef<UnlockWalletComponent, any> {
   const config = new MatDialogConfig();
   config.width = '500px';
   config.data = wallet;
@@ -60,6 +61,26 @@ export function showConfirmationModal(dialog: MatDialog, confirmationData: Confi
     width: '450px',
     data: confirmationData,
     autoFocus: false
+  });
+}
+
+export function openDeleteWalletModal (dialog: MatDialog, wallet: Wallet, translateService: TranslateService, walletService: WalletService) {
+  const mainText = translateService.instant('wallet.delete-confirmation1') + ' \"' +
+    wallet.label + '\" ' +
+    translateService.instant('wallet.delete-confirmation2');
+
+  const confirmationData: ConfirmationData = {
+    text: mainText,
+    headerText: 'confirmation.header-text',
+    checkboxText: 'wallet.delete-confirmation-check',
+    confirmButtonText: 'confirmation.confirm-button',
+    cancelButtonText: 'confirmation.cancel-button'
+  };
+
+  showConfirmationModal(dialog, confirmationData).afterClosed().subscribe(result => {
+    if (result) {
+      walletService.delete(wallet);
+    }
   });
 }
 

--- a/src/app/utils/index.ts
+++ b/src/app/utils/index.ts
@@ -5,7 +5,7 @@ import { Observable } from 'rxjs/Observable';
 import { TranslateService } from '@ngx-translate/core';
 
 import { Wallet, ConfirmationData } from '../app.datatypes';
-import { UnlockWalletComponent, ComfirmSeedParams } from '../components/pages/wallets/unlock-wallet/unlock-wallet.component';
+import { UnlockWalletComponent, ConfirmSeedParams } from '../components/pages/wallets/unlock-wallet/unlock-wallet.component';
 import { SelectCoinOverlayComponent } from '../components/layout/select-coin-overlay/select-coin-overlay.component';
 import { SelectLanguageComponent } from '../components/layout/select-language/select-language.component';
 import { QrCodeComponent } from '../components/layout/qr-code/qr-code.component';
@@ -14,7 +14,7 @@ import { BlockchainService, ProgressStates } from '../services/blockchain.servic
 import { ScanAddressesComponent } from '../components/pages/wallets/scan-addresses/scan-addresses.component';
 import { WalletService } from '../services/wallet/wallet.service';
 
-export function openUnlockWalletModal (wallet: Wallet | ComfirmSeedParams, unlockDialog: MatDialog): MatDialogRef<UnlockWalletComponent, any> {
+export function openUnlockWalletModal (wallet: Wallet | ConfirmSeedParams, unlockDialog: MatDialog): MatDialogRef<UnlockWalletComponent, any> {
   const config = new MatDialogConfig();
   config.width = '500px';
   config.data = wallet;

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -132,6 +132,8 @@
     "load": "Load Wallet",
     "locked": "Locked",
     "wallet": "Wallet",
+    "locked-tooltip": "The seed is necessary to send transactions",
+    "unlocked-tooltip": "Wallet temporarily unlocked to send transactions",
     "delete-confirmation1": "WARNING: the wallet",
     "delete-confirmation2": "will be deleted. If you forget your seed, you will not be able to recover this wallet! Do you want to continue?",
     "delete-confirmation-check": "Yeah, I want to delete the wallet.",
@@ -169,6 +171,11 @@
 
     "unlock": {
       "unlock-title": "Unlock Wallet",
+      "confirmation-warning-title": "Important: without the seed you will lose access to your funds",
+      "confirmation-warning-text1": "For security reasons, the seed of this wallet will not be saved and it will frequently be requested before sending transactions. If you did not safeguard it, you will lose access to the funds. To confirm that you have safeguarded the seed and to be able to see the addresses of this wallet, please re-enter the seed in the box below and add a question mark (?) at the end of it.",
+      "confirmation-warning-text2-1": "If you do not have the seed, you can delete the wallet by clicking",
+      "confirmation-warning-text2-2": "here.",
+      "confirmation-warning-text3": "Enter the seed with the requested format to activate the \"Unlock\" button.",
       "seed": "Seed",
       "cancel-button": "Cancel",
       "unlock-button": "Unlock"

--- a/src/assets/i18n/es.json
+++ b/src/assets/i18n/es.json
@@ -132,6 +132,8 @@
     "load": "Cargar Billetera",
     "locked": "Bloqueada",
     "wallet": "Billetera",
+    "locked-tooltip": "Es necesaria la semilla para poder enviar transacciones",
+    "unlocked-tooltip": "Billetera temporalmente desbloqueada para enviar transacciones",
     "delete-confirmation1": "ADVERTENCIA: la billetera",
     "delete-confirmation2": "será eliminada. ¡Si olvida su semilla, no podrá recuperar esta billetera! ¿Desea continuar?",
     "delete-confirmation-check": "Sí, quiero eliminar la billetera.",
@@ -169,6 +171,11 @@
 
     "unlock": {
       "unlock-title": "Desbloquear Billetera",
+      "confirmation-warning-title": "Importante: sin la semilla usted perderá el acceso a sus fondos",
+      "confirmation-warning-text1": "Por medidas de seguridad, la semilla de esta billetera no será guardada y frecuentemente se le solicitará antes de enviar transacciones. Si no la resguardó, perderá acceso a los fondos. Para confirmar que ha resguardado la semilla y poder ver las direcciones de esta billetera, por favor vuelva a introducir la semilla en el recuadro de abajo y añádale un signo de interrogación (?) al final.",
+      "confirmation-warning-text2-1": "Si no tiene la semilla, puede borrar la billetera presionando",
+      "confirmation-warning-text2-2": "aquí.",
+      "confirmation-warning-text3": "Introduzca la semilla con el formato solicitado para activar el botón \"Desbloquear\".",
       "seed": "Semilla",
       "cancel-button": "Cancelar",
       "unlock-button": "Desbloquear"

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -378,3 +378,8 @@ General Helpers
 .mat-dialog-content {
   max-height: 80vh !important;
 }
+
+.link {
+  color: $blue;
+  cursor: pointer;
+}


### PR DESCRIPTION
During the last tests it became obvious that it is necessary to make it clear to the user that the web wallet does not save the seeds as the desktop wallet does and that it is absolutely necessary to safeguard the seeds or the funds could become inaccessible.

Changes:
- With this pr if the user tries to see the addresses of a newly created wallet the following modal window is displayed requesting the seed, in order to confirm if the user has safeguarded the seed:
![modal](https://user-images.githubusercontent.com/34079003/49706477-7ea6ef80-fbfc-11e8-9e66-eede09ccb206.png)
- In the modal window the user must add an additional question mark at the end of the seed (it s indicated in the instructions text). This is to ensure that the user reads the instructions.
- Once the user places the seed correctly, the modal window is not shown again when the users tries to see the addresses of that wallet.
- The modal window is only displayed for wallets created with the option to create a new wallet (either on the wallets page or the onboarding page), not when using the option to load a wallet with a pre-existing seed.
- The modal window has an option that allows the user to delete the wallet in case he has not saved the seed.
