### PR TITLE
Validate custom node Urls

### DIFF
--- a/src/app/components/pages/settings/nodes/change-url/change-node-url.component.html
+++ b/src/app/components/pages/settings/nodes/change-url/change-node-url.component.html
@@ -1,16 +1,31 @@
-<app-modal class="modal" [headline]="'nodes.change-url' | translate" [dialog]="dialogRef">
-  <div [formGroup]="form">
+<app-modal class="modal" [headline]="'nodes.change-url' | translate" [dialog]="dialogRef" [disableDismiss]="disableDismiss">
+  <div [formGroup]="form" *ngIf="showingUrlForm">
     <div class="form-field">
       <label for="url">{{ 'nodes.change.url-label' | translate}}</label>
       <input formControlName="url" id="url" (keydown.enter)="change()">
     </div>
   </div>
+  <div class="property-container" *ngIf="!showingUrlForm">
+    <h4>{{ 'nodes.change.node-properties' | translate}}</h4>
+    <div class="data">
+      <span>{{ 'nodes.change.coin-name' | translate }}:</span> <span>{{ coinName }}</span>
+    </div>
+    <div class="data">
+      <span>{{ 'nodes.change.node-version' | translate }}:</span> <span>{{ nodeVersion }}</span>
+    </div>
+    <div class="data">
+      <span>{{ 'nodes.change.last-block' | translate }}:</span> <span>{{ lastBlock }}</span>
+    </div>
+    <div class="data">
+      <span>{{ 'nodes.change.hours-burn-rate' | translate }}:</span> <span>{{ hoursBurnRate }}</span>
+    </div>
+  </div>
   <div class="-buttons">
-    <app-button (action)="closePopup()">
-      {{ 'nodes.change.cancel-button' | translate}}
+    <app-button (action)="showingUrlForm ? closePopup() : showUrlForm()" [disabled]="disableDismiss">
+      {{ (showingUrlForm ? 'nodes.change.cancel-button' : 'nodes.change.return-button') | translate}}
     </app-button>
-    <app-button (action)="change()" class="primary">
-      {{ 'nodes.change.change-button' | translate}}
+    <app-button (action)="showingUrlForm ? startChange() : completeChange()" class="primary" #action>
+      {{ (showingUrlForm ? 'nodes.change.verify-button' : 'nodes.change.change-button') | translate}}
     </app-button>
   </div>
 </app-modal>

--- a/src/app/components/pages/settings/nodes/change-url/change-node-url.component.scss
+++ b/src/app/components/pages/settings/nodes/change-url/change-node-url.component.scss
@@ -1,0 +1,27 @@
+@import '../../../../../../theme/variables';
+
+.property-container {
+  display: table;
+
+  h4 {
+    font-size: 14px;
+    margin: 0 0 10px;
+  }
+
+  .data {
+    font-size: 12px;
+    display: table-row;
+
+    span {
+      display: table-cell;
+    }
+
+    span:first-child {
+      color: $grey;
+      padding-right: 20px;
+    }
+    span:last-child {
+      word-break: break-all;
+    }
+  }
+}

--- a/src/app/components/pages/settings/nodes/change-url/change-node-url.component.spec.ts
+++ b/src/app/components/pages/settings/nodes/change-url/change-node-url.component.spec.ts
@@ -1,7 +1,9 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { NO_ERRORS_SCHEMA } from '@angular/core';
-import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material';
+import { MAT_DIALOG_DATA, MatDialogRef, MatSnackBarModule } from '@angular/material';
 import { FormBuilder } from '@angular/forms';
+import { HttpClientModule } from '@angular/common/http';
+import { TranslateService } from '@ngx-translate/core';
 
 import { ChangeNodeURLComponent } from './change-node-url.component';
 import { MockTranslatePipe, MockCoinService } from '../../../../../utils/test-mocks';
@@ -14,12 +16,17 @@ describe('ChangeNodeURLComponent', () => {
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       declarations: [ ChangeNodeURLComponent, MockTranslatePipe ],
+      imports: [ HttpClientModule, MatSnackBarModule ],
       schemas: [ NO_ERRORS_SCHEMA ],
       providers: [
         FormBuilder,
         { provide: CoinService, useClass: MockCoinService },
         { provide: MatDialogRef, useValue: {} },
-        { provide: MAT_DIALOG_DATA, useValue: {} }
+        { provide: MAT_DIALOG_DATA, useValue: {} },
+        {
+          provide: TranslateService,
+          useValue: jasmine.createSpyObj('TranslateService', ['instant'])
+        },
       ]
     })
     .compileComponents();

--- a/src/app/components/pages/settings/nodes/change-url/change-node-url.component.ts
+++ b/src/app/components/pages/settings/nodes/change-url/change-node-url.component.ts
@@ -1,35 +1,131 @@
-import { Component, Inject, OnInit, ViewChild } from '@angular/core';
-import { FormBuilder, FormGroup, Validators } from '@angular/forms';
+import { Component, Inject, OnInit, ViewChild, OnDestroy } from '@angular/core';
+import { FormBuilder, FormGroup } from '@angular/forms';
 import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
+import { ISubscription } from 'rxjs/Subscription';
+import BigNumber from 'bignumber.js';
+import { HttpClient } from '@angular/common/http';
+import { MatSnackBarConfig, MatSnackBar } from '@angular/material';
+import { TranslateService } from '@ngx-translate/core';
 
 import { CoinService } from '../../../../../services/coin.service';
+import { ButtonComponent } from '../../../../layout/button/button.component';
+import { isEqualOrSuperiorVersion } from '../../../../../utils/semver';
 
 @Component({
   selector: 'app-change-node-url',
   templateUrl: './change-node-url.component.html',
   styleUrls: ['./change-node-url.component.scss'],
 })
-export class ChangeNodeURLComponent implements OnInit {
+export class ChangeNodeURLComponent implements OnInit, OnDestroy {
+  @ViewChild('action') actionButton: ButtonComponent;
+
+  disableDismiss = false;
+  showingUrlForm = true;
   form: FormGroup;
+
+  nodeVersion: string;
+  lastBlock: number;
+  hoursBurnRate: string;
+  coinName: string;
+
+  private newUrl: string;
+  private verificationSubscription: ISubscription;
 
   constructor(
     @Inject(MAT_DIALOG_DATA) private data: {coinId: number, url: string},
     public dialogRef: MatDialogRef<ChangeNodeURLComponent>,
     private formBuilder: FormBuilder,
-    private coinService: CoinService
+    private coinService: CoinService,
+    private http: HttpClient,
+    private snackBar: MatSnackBar,
+    private translate: TranslateService,
   ) {}
 
   ngOnInit() {
     this.initForm();
   }
 
+  ngOnDestroy() {
+    this.removeVerificationSubscription();
+    this.snackBar.dismiss();
+  }
+
   closePopup() {
     this.dialogRef.close();
   }
 
-  change() {
-    this.coinService.changeNodeUrl(this.data.coinId, this.form.value.url.trim());
+  startChange() {
+    this.snackBar.dismiss();
+
+    this.newUrl = this.form.value.url.trim();
+
+    if (this.newUrl !== '') {
+      this.actionButton.setLoading();
+      this.disableDismiss = true;
+
+      if (this.newUrl.endsWith('/')) {
+        this.newUrl = this.newUrl.substr(0, this.newUrl.length - 1);
+      }
+
+      this.removeVerificationSubscription();
+
+      this.verificationSubscription = this.http.get(this.newUrl + '/api/v1/health').subscribe((response: any) => {
+        this.nodeVersion = response.version.version;
+        this.lastBlock = response.blockchain.head.seq;
+        this.hoursBurnRate = new BigNumber(100).dividedBy(response.user_verify_transaction.burn_factor).decimalPlaces(3, BigNumber.ROUND_FLOOR).toString() + '%';
+        this.coinName = response.coin;
+
+        if (!isEqualOrSuperiorVersion(this.nodeVersion, '0.24.0')) {
+          this.cancelChange(true, false);
+          return;
+        } else if (response.csrf_enabled) {
+          this.cancelChange(false, true);
+          return;
+        }
+
+        this.actionButton.resetState();
+        this.disableDismiss = false;
+        this.showingUrlForm = false;
+
+      }, () => this.cancelChange(false, false));
+    } else {
+      this.completeChange();
+    }
+  }
+
+  showUrlForm() {
+    this.removeVerificationSubscription();
+    this.showingUrlForm = true;
+  }
+
+  completeChange() {
+    this.coinService.changeNodeUrl(this.data.coinId, this.newUrl);
     this.closePopup();
+  }
+
+  private cancelChange(invalidNodeVersion: boolean, csrfActivated: boolean) {
+    this.actionButton.resetState();
+    this.disableDismiss = false;
+
+    let errorMesasge: string;
+    if (invalidNodeVersion) {
+      errorMesasge = this.translate.instant('nodes.change.invalid-version-error');
+    } else if (csrfActivated) {
+      errorMesasge = this.translate.instant('nodes.change.csrf-error');
+    } else {
+      errorMesasge = this.translate.instant('nodes.change.connection-error');
+    }
+
+    const config = new MatSnackBarConfig();
+    config.duration = 5000;
+    this.snackBar.open(errorMesasge, null, config);
+    this.actionButton.setError(errorMesasge);
+  }
+
+  private removeVerificationSubscription() {
+    if (this.verificationSubscription) {
+      this.verificationSubscription.unsubscribe();
+    }
   }
 
   private initForm() {

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -282,7 +282,7 @@
       "coin-name": "Coin",
       "node-version": "Node version",
       "last-block": "Last block",
-      "hours-burn-rate": "hours burn rate"
+      "hours-burn-rate": "Hours burn rate"
     }
   },
 

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -272,7 +272,17 @@
     "change" : {
       "url-label": "Node URL (leave empty to use the default URL)",
       "cancel-button": "Cancel",
-      "change-button": "Change"
+      "change-button": "Change",
+      "return-button": "Return",
+      "verify-button": "Verify",
+      "connection-error": "It was not possible to connect to the node. Please check the URL and your internet connection and try again.",
+      "csrf-error": "It is not possible to connect to the specified node since it is configured to use CSRF tokens.",
+      "invalid-version-error": "The specified node is not compatible with this wallet. The node must be updated to at least version 0.24.0.",
+      "node-properties": "Node properties",
+      "coin-name": "Coin",
+      "node-version": "Node version",
+      "last-block": "Last block",
+      "hours-burn-rate": "hours burn rate"
     }
   },
 

--- a/src/assets/i18n/es.json
+++ b/src/assets/i18n/es.json
@@ -272,7 +272,17 @@
     "change" : {
       "url-label": "URL del nodo (dejar vacío para usar la URL por defecto)",
       "cancel-button": "Cancelar",
-      "change-button": "Cambiar"
+      "change-button": "Cambiar",
+      "return-button": "Regresar",
+      "verify-button": "Verificar",
+      "connection-error": "No fue posible conectarse con el nodo. Por favor, revise la URL y su conexión a Internet y vuelva a intentarlo.",
+      "csrf-error": "No es posible conectarse al nodo especificado debido a que está configurado para usar tokens CSRF.",
+      "invalid-version-error": "El nodo especificado no es compatible con esta billetera. El nodo debe estar actualizado al menos a la versión 0.24.0.",
+      "node-properties": "Propiedades del nodo",
+      "coin-name": "Moneda",
+      "node-version": "Versión del nodo",
+      "last-block": "Último bloque",
+      "hours-burn-rate": "Tasa de quema de horas"
     }
   },
 


### PR DESCRIPTION
Fixes #490

Changes:
- Now, when trying to change the URL of the node, the URL and the node version are verified with a call to the `/health` endpoint.
- Before making the URL change, the user can see some of the properties of the new node.