### PR TITLE
Stop asking for a question mark to confirm the seed

### DIFF
--- a/e2e/wallets.po.ts
+++ b/e2e/wallets.po.ts
@@ -315,7 +315,7 @@ export class WalletsPage {
       return seedField.isPresent().then((status) => {
         if (status) {
           seedField.clear();
-          seedField.sendKeys(seed + '?');
+          seedField.sendKeys(seed);
 
           const btnUnlock = element(by.buttonText('Unlock'));
           btnUnlock.click();

--- a/src/app/components/pages/wallets/unlock-wallet/unlock-wallet.component.html
+++ b/src/app/components/pages/wallets/unlock-wallet/unlock-wallet.component.html
@@ -19,9 +19,6 @@
       <textarea formControlName="seed" id="seed" row="2"></textarea>
     </div>
   </div>
-  <div *ngIf="showConfirmSeedWarning">
-    <div>{{ 'wallet.unlock.confirmation-warning-text3' | translate }}</div>
-  </div>
   <div class="-buttons">
     <app-button (action)="closePopup()" [disabled]="disableDismiss">
       {{ 'wallet.unlock.cancel-button' | translate }}

--- a/src/app/components/pages/wallets/unlock-wallet/unlock-wallet.component.ts
+++ b/src/app/components/pages/wallets/unlock-wallet/unlock-wallet.component.ts
@@ -69,11 +69,7 @@ export class UnlockWalletComponent implements OnInit, OnDestroy {
       this.progressSubscription = onProgressChanged.subscribe((progress) => this.loadingProgress = progress);
     }
 
-    const seed = !this.showConfirmSeedWarning ?
-      this.form.value.seed :
-      (this.form.value.seed as string).substr(0, (this.form.value.seed as string).length - 1);
-
-    this.unlockSubscription = this.walletService.unlockWallet(this.wallet, seed, onProgressChanged)
+    this.unlockSubscription = this.walletService.unlockWallet(this.wallet, this.form.value.seed, onProgressChanged)
       .subscribe(
         () => this.onUnlockSuccess(),
         (error: Error) => this.onUnlockError(error)
@@ -89,13 +85,6 @@ export class UnlockWalletComponent implements OnInit, OnDestroy {
     this.form = this.formBuilder.group({
       seed: ['', Validators.required],
     });
-
-    if (this.showConfirmSeedWarning) {
-      this.form.controls.seed.setValidators([
-        Validators.required,
-        this.validateSeedConfirmation,
-      ]);
-    }
   }
 
   private onUnlockSuccess() {
@@ -121,13 +110,5 @@ export class UnlockWalletComponent implements OnInit, OnDestroy {
     if (this.unlockSubscription && !this.unlockSubscription.closed) {
       this.unlockSubscription.unsubscribe();
     }
-  }
-
-  private validateSeedConfirmation(seedControl: FormControl) {
-    if (!(seedControl.value as string).endsWith('?')) {
-      return { Invalid: true };
-    }
-
-    return null;
   }
 }

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -172,10 +172,9 @@
     "unlock": {
       "unlock-title": "Unlock Wallet",
       "confirmation-warning-title": "Important: without the seed you will lose access to your funds",
-      "confirmation-warning-text1": "For security reasons, the seed of this wallet will not be saved and it will frequently be requested before sending transactions. If you did not safeguard it, you will lose access to the funds. To confirm that you have safeguarded the seed and to be able to see the addresses of this wallet, please re-enter the seed in the box below and add a question mark (?) at the end of it.",
+      "confirmation-warning-text1": "For security reasons, this wallet will not be saved and you will need the seed to access it again after closing/refreshing the current browser tab. If you did not safeguard it, you will lose access to the funds. To confirm that you have safeguarded the seed and to be able to see the addresses of this wallet, please re-enter the seed in the box below.",
       "confirmation-warning-text2-1": "If you do not have the seed, you can delete the wallet by clicking",
       "confirmation-warning-text2-2": "here.",
-      "confirmation-warning-text3": "Enter the seed with the requested format to activate the \"Unlock\" button.",
       "seed": "Seed",
       "cancel-button": "Cancel",
       "unlock-button": "Unlock"

--- a/src/assets/i18n/es.json
+++ b/src/assets/i18n/es.json
@@ -172,10 +172,9 @@
     "unlock": {
       "unlock-title": "Desbloquear Billetera",
       "confirmation-warning-title": "Importante: sin la semilla usted perderá el acceso a sus fondos",
-      "confirmation-warning-text1": "Por medidas de seguridad, la semilla de esta billetera no será guardada y frecuentemente se le solicitará antes de enviar transacciones. Si no la resguardó, perderá acceso a los fondos. Para confirmar que ha resguardado la semilla y poder ver las direcciones de esta billetera, por favor vuelva a introducir la semilla en el recuadro de abajo y añádale un signo de interrogación (?) al final.",
+      "confirmation-warning-text1": "Por medidas de seguridad, esta billetera no será guardada y necesitará la semilla para acceder a ella nuevamente después de cerrar/refrescar la pestaña actual del explorador. Si no la resguardó, perderá acceso a los fondos. Para confirmar que ha resguardado la semilla y poder ver las direcciones de esta billetera, por favor vuelva a introducir la semilla en el recuadro de abajo.",
       "confirmation-warning-text2-1": "Si no tiene la semilla, puede borrar la billetera presionando",
       "confirmation-warning-text2-2": "aquí.",
-      "confirmation-warning-text3": "Introduzca la semilla con el formato solicitado para activar el botón \"Desbloquear\".",
       "seed": "Semilla",
       "cancel-button": "Cancelar",
       "unlock-button": "Desbloquear"


### PR DESCRIPTION
Changes:
- With this PR, when the user creates a new wallet and tries to see the addresses, the modal window that asks the user to confirm the seed before continuing is still shown, but it is no longer ask to add a question mark at the end of the seed.