### PR TITLE
Allow to add more wallets

### DIFF
--- a/src/app/services/wallet/wallet.service.ts
+++ b/src/app/services/wallet/wallet.service.ts
@@ -153,8 +153,9 @@ export class WalletService {
         strippedWallets.push({ coinId: wallet.coinId, needSeedConfirmation: wallet.needSeedConfirmation, label: wallet.label, addresses: strippedAddresses });
       });
       localStorage.setItem('wallets', JSON.stringify(strippedWallets));
-      this.wallets.next(this.wallets.value);
     }
+
+    this.wallets.next(this.wallets.value);
   }
 
   private loadWallets() {


### PR DESCRIPTION
Changes:
- This PR fixes a problem added in the PR that stoped saving the data in the production builds. The problem is that after adding the first wallet on the wizard, any newly added wallet do not appear in the wallet list.
