### PR TITLE
Check if the crypto library can be used inside a worker

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,4 +1,10 @@
-<div class="size-alert">
+<div class="crypto-alert" *ngIf="!browserHasCryptoInsideWorkers">
+  <div>
+    <mat-icon>error</mat-icon>
+    <div>{{ 'errors.crypto-no-available' | translate }}</div>
+  </div>
+</div>
+<div class="size-alert" *ngIf="browserHasCryptoInsideWorkers">
   <div>
     <img src="assets/img/size-alert.png">
     <div>{{ 'errors.window-size' | translate }}</div>

--- a/src/app/app.component.scss
+++ b/src/app/app.component.scss
@@ -1,5 +1,34 @@
 $white: #FBFBFB;
 
+.crypto-alert {
+  background-color: rgba(0, 0, 0, 0.85);
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  z-index: 10000;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  color: white;
+  font-size: 14px;
+  line-height: 1.5;
+
+  > div {
+    margin: 0px 40px;
+    max-width: 400px;
+
+    mat-icon {
+      font-size: 50px;
+      height: 50px;
+      width: 50px;
+      opacity: 0.7;
+    }
+  }
+}
+
 .size-alert {
   background-color: rgba(0, 0, 0, 0.85);
   position: fixed;

--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -1,9 +1,11 @@
 import { TestBed, async, ComponentFixture } from '@angular/core/testing';
 import { NO_ERRORS_SCHEMA } from '@angular/core';
+import { BehaviorSubject } from 'rxjs/BehaviorSubject';
 
 import { AppComponent } from './app.component';
 import { MockLanguageService, MockTranslatePipe } from './utils/test-mocks';
 import { LanguageService } from './services/language.service';
+import { CipherProvider } from './services/cipher.provider';
 
 describe('AppComponent', () => {
   let component: AppComponent;
@@ -14,7 +16,8 @@ describe('AppComponent', () => {
       declarations: [ AppComponent, MockTranslatePipe ],
       schemas: [ NO_ERRORS_SCHEMA ],
       providers: [
-        { provide: LanguageService, useClass: MockLanguageService }
+        { provide: LanguageService, useClass: MockLanguageService },
+        { provide: CipherProvider, useValue: { browserHasCryptoInsideWorkers: new BehaviorSubject<boolean>(true) } }
       ]
     }).compileComponents();
   }));

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -2,6 +2,7 @@ import { Component, OnInit } from '@angular/core';
 import { LanguageService } from './services/language.service';
 
 import { config } from './app.config';
+import { CipherProvider } from './services/cipher.provider';
 
 @Component({
   selector: 'app-root',
@@ -16,10 +17,16 @@ export class AppComponent implements OnInit {
   appStoreUrl: string;
   googlePlayUrl: string;
   isElectron: boolean;
+  browserHasCryptoInsideWorkers: boolean;
 
   constructor(
-    private languageService: LanguageService
-  ) {}
+    private languageService: LanguageService,
+    cipherProvider: CipherProvider
+  ) {
+    cipherProvider.browserHasCryptoInsideWorkers.subscribe(value => {
+      this.browserHasCryptoInsideWorkers = value;
+    });
+  }
 
   ngOnInit() {
     this.otcEnabled = config.otcEnabled;

--- a/src/app/services/cipher.provider.ts
+++ b/src/app/services/cipher.provider.ts
@@ -1,5 +1,6 @@
 import { Injectable } from '@angular/core';
 import { Observable } from 'rxjs/Observable';
+import { BehaviorSubject } from 'rxjs/BehaviorSubject';
 
 import { Address, TransactionInput, TransactionOutput } from '../app.datatypes';
 import { CipherWebWorkerHelper, CipherWebWorkerOperation } from '../utils/cipher-web-worker-helper';
@@ -7,8 +8,10 @@ import { CipherWebWorkerHelper, CipherWebWorkerOperation } from '../utils/cipher
 @Injectable()
 export class CipherProvider {
 
+  browserHasCryptoInsideWorkers: BehaviorSubject<boolean> = new BehaviorSubject<boolean>(true);
+
   constructor() {
-    CipherWebWorkerHelper.initialize();
+    CipherWebWorkerHelper.initialize(this);
   }
 
   generateAddress(seed): Observable<Address> {

--- a/src/app/utils/cipher-web-worker-helper.ts
+++ b/src/app/utils/cipher-web-worker-helper.ts
@@ -13,15 +13,19 @@ export enum CipherWebWorkerOperation {
 export class CipherWebWorkerHelper {
 
   private static readonly errPrefix = 'Error:';
+  private static readonly browserWithputCryptoErrorMsg = 'No crypto';
 
   private static worker: Worker;
 
   private static readonly activeWorks: Map<number, Subject<any>> = new Map<number, Subject<any>>();
   private static initialized = false;
+  private static mainService: any;
 
-  static initialize() {
+  static initialize(mainService: any) {
     if (!CipherWebWorkerHelper.initialized) {
       CipherWebWorkerHelper.initialized = true;
+
+      CipherWebWorkerHelper.mainService = mainService;
 
       if (!environment.e2eTest) {
         System.import(`../../assets/scripts/cipher-web-worker.js`).then((content) => {
@@ -73,6 +77,8 @@ export class CipherWebWorkerHelper {
           CipherWebWorkerHelper.errPrefix.length,
           (e.data.result as string).length - CipherWebWorkerHelper.errPrefix.length)
       ));
+    } else if (isString(e.data.result) && (e.data.result as string).startsWith(CipherWebWorkerHelper.browserWithputCryptoErrorMsg)) {
+      CipherWebWorkerHelper.mainService.browserHasCryptoInsideWorkers.next(false);
     } else {
       // Return the result.
       CipherWebWorkerHelper.activeWorks[e.data.workID].next(e.data.result);

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -14,7 +14,8 @@
     "no-outputs": "No unspent outputs",
     "no-wallets": "Currently there are no wallets",
     "window-size": "The window is too narrow for the content.",
-    "loading-error": "Error trying to get the data. Please try again later."
+    "loading-error": "Error trying to get the data. Please try again later.",
+    "crypto-no-available": "The web browser you are using is not compatible with this wallet (the crypto library is not available). Please update your browser or try using another."
   },
 
   "title": {

--- a/src/assets/i18n/es.json
+++ b/src/assets/i18n/es.json
@@ -14,7 +14,8 @@
     "no-outputs": "No hay salidas no gastadas",
     "no-wallets": "Actualmente no hay billeteras",
     "window-size": "La ventana es muy angosta para el contenido.",
-    "loading-error": "Error al intentar obtener los datos. Por favor, inténtelo nuevamente más tarde."
+    "loading-error": "Error al intentar obtener los datos. Por favor, inténtelo nuevamente más tarde.",
+    "crypto-no-available": "El explorador web que usted está usando no es compatible con esta billetera (la librería crypto no está disponible). Por favor, actualice su navegador o intente con otro."
   },
 
   "title": {

--- a/src/assets/scripts/cipher-web-worker.js
+++ b/src/assets/scripts/cipher-web-worker.js
@@ -3,8 +3,17 @@ var onmessage = function(e) {
     try {
       switch(e.data.operation) {
         case 0: {
-          importScripts(e.data.url + '/assets/scripts/main.js');
-          break;
+          try {
+            var hasCrypto = crypto;
+          } catch (e) {}
+
+          if (hasCrypto) {
+            importScripts(e.data.url + '/assets/scripts/main.js');
+            break;
+          } else {
+            postMessage({result: 'No crypto', workID: 0});
+            break;
+          }
         }
         case 1: {
           postMessage({result: Cipher.GenerateAddresses(e.data.data), workID: e.data.workID});


### PR DESCRIPTION
Changes:
- Now the wallet checks if the browser allows to access the `crypto` library inside a worker. If the check fails, an error message is displayed to the user stating that the wallet is not compatible with the browser.

Just like https://github.com/skycoin/skycoin-web/pull/509, this change was already made in https://github.com/skycoin/skycoin-web/pull/506, but I'm putting it in a separate PR so it can be reviewed and merged more easily in case that PR takes a long time to be merged, so that the users can start testing the wallet in less time.