### PR TITLE
Improve the outputs selection procedure

### DIFF
--- a/src/app/services/wallet/spending.service.spec.ts
+++ b/src/app/services/wallet/spending.service.spec.ts
@@ -72,7 +72,7 @@ describe('SpendingService', () => {
   describe('createTransaction', () => {
     it('should return a correct observable for two outputs', fakeAsync(() => {
       const address = 'address';
-      const amount = new BigNumber(21);
+      const amount = new BigNumber(26);
 
       const addresses = [
         createAddress('address1', 'secretKey1'),
@@ -85,24 +85,25 @@ describe('SpendingService', () => {
         createOutput('address1', 'hash1', new BigNumber(5), new BigNumber(10)),
         createOutput('address2', 'hash2', new BigNumber(10), new BigNumber(20)),
         createOutput('address1', 'hash1', new BigNumber(20), new BigNumber(50)),
-        createOutput('address2', 'hash2', new BigNumber(50), new BigNumber(0))
+        createOutput('address2', 'hash2', new BigNumber(5), new BigNumber(0))
       ];
 
       const expectedTxInputs: TransactionInput[] = [
         { hash: 'hash1', secret: 'secretKey1', address: 'address1', calculated_hours: 50, coins: 20 },
-        { hash: 'hash2', secret: 'secretKey2', address: 'address2', calculated_hours: 20, coins: 10 }
+        { hash: 'hash2', secret: 'secretKey2', address: 'address2', calculated_hours: 0, coins: 5 },
+        { hash: 'hash1', secret: 'secretKey1', address: 'address1', calculated_hours: 10, coins: 5 }
       ];
 
       const expectedTxOutputs: TransactionOutput[] = [
         {
           address: wallet.addresses[0].address,
-          coins: 9,
-          hours: 18
+          coins: 4,
+          hours: 15
         },
         {
           address: address,
-          coins: 21,
-          hours: 17
+          coins: 26,
+          hours: 15
         }
       ];
 
@@ -114,8 +115,8 @@ describe('SpendingService', () => {
           expect(result).toEqual({
             inputs: expectedTxInputs,
             outputs: expectedTxOutputs,
-            hoursSent: new BigNumber(17),
-            hoursBurned: new BigNumber(35),
+            hoursSent: new BigNumber(15),
+            hoursBurned: new BigNumber(30),
             encoded: 'preparedTransaction'
           });
         });
@@ -174,11 +175,12 @@ describe('SpendingService', () => {
       const wallet: Wallet = Object.assign(createWallet(), { addresses: addresses });
 
       const outputs: Output[] = [
-        createOutput('address1', 'hash1', new BigNumber(1), new BigNumber(24)),
+        createOutput('address1', 'hash1', new BigNumber(1), new BigNumber(0)),
         createOutput('address2', 'hash2', new BigNumber(1), new BigNumber(0))
       ];
 
       spyApiService.get.and.returnValue(Observable.of({ head_outputs: outputs }));
+      spyCipherProvider.prepareTransaction.and.returnValue(Observable.of('preparedTransaction'));
       spyTranslateService.instant.and.callFake((param) => {
         if (param === 'service.wallet.not-enough-hours1') {
           return 'Not enough available';

--- a/src/app/services/wallet/spending.service.ts
+++ b/src/app/services/wallet/spending.service.ts
@@ -201,16 +201,78 @@ export class SpendingService {
     return this.cipherProvider.prepareTransaction(txInputs, convertedOutputs);
   }
 
+  private sortOutputs(outputs: Output[], highestToLowest: boolean) {
+    outputs.sort((a, b) => {
+      if (b.coins.isGreaterThan(a.coins)) {
+        return highestToLowest ? 1 : -1;
+      } else if (b.coins.isLessThan(a.coins)) {
+        return highestToLowest ? -1: 1;
+      } else {
+        if (b.calculated_hours.isGreaterThan(a.calculated_hours)) {
+          return -1;
+        } else if (b.calculated_hours.isLessThan(a.calculated_hours)) {
+          return 1;
+        } else {
+          return 0;
+        }
+      }
+    });
+  }
+
   private getMinRequiredOutputs(transactionAmount: BigNumber, outputs: Output[]): Output[] {
-    outputs.sort( function(a, b) {
-      return b.coins.minus(a.coins).toNumber();
+
+    // Split the outputs into those with and without hours
+    const outputsWithHours: Output[] = [];
+    const outputsWitouthHours: Output[] = [];
+    outputs.forEach(output => {
+      if (output.calculated_hours.isGreaterThan(0)) {
+        outputsWithHours.push(output);
+      } else {
+        outputsWitouthHours.push(output);
+      }
     });
 
-    const minRequiredOutputs: Output[] = [];
-    let sumCoins: BigNumber = new BigNumber('0');
+    // Abort if there are no outputs with non-zero coinhours.
+    if (outputsWithHours.length === 0) {
+      return [];
+    }
 
-    outputs.forEach(output => {
-      if (sumCoins.isLessThan(transactionAmount) && output.calculated_hours.isGreaterThan(0)) {
+    // Sort the outputs with hours by coins, from highest to lowest. If two items have the same amount of
+    // coins, the one with the least hours is placed first.
+    this.sortOutputs(outputsWithHours, true);
+
+    // Use the first nonzero output.
+    const minRequiredOutputs: Output[] = [outputsWithHours[0]];
+    let sumCoins: BigNumber = new BigNumber(outputsWithHours[0].coins);
+
+    // If it's enough, finish.
+    if (sumCoins.isGreaterThanOrEqualTo(transactionAmount)) {
+      return minRequiredOutputs;
+    }
+
+    // Sort the outputs without hours by coins, from lowest to highest.
+    this.sortOutputs(outputsWitouthHours, false);
+
+    // Add the outputs without hours, until having the necessary amount of coins.
+    outputsWitouthHours.forEach(output => {
+      if (sumCoins.isLessThan(transactionAmount)) {
+        minRequiredOutputs.push(output);
+        sumCoins = sumCoins.plus(output.coins);
+      }
+    });
+
+    // If it's enough, finish.
+    if (sumCoins.isGreaterThanOrEqualTo(transactionAmount)) {
+      return minRequiredOutputs;
+    }
+
+    outputsWithHours.splice(0, 1);
+    // Sort the outputs with hours by coins, from lowest to highest.
+    this.sortOutputs(outputsWithHours, false);
+
+    // Add the outputs with hours, until having the necessary amount of coins.
+    outputsWithHours.forEach((output) => {
+      if (sumCoins.isLessThan(transactionAmount)) {
         minRequiredOutputs.push(output);
         sumCoins = sumCoins.plus(output.coins);
       }

--- a/src/app/services/wallet/spending.service.ts
+++ b/src/app/services/wallet/spending.service.ts
@@ -206,7 +206,7 @@ export class SpendingService {
       if (b.coins.isGreaterThan(a.coins)) {
         return highestToLowest ? 1 : -1;
       } else if (b.coins.isLessThan(a.coins)) {
-        return highestToLowest ? -1: 1;
+        return highestToLowest ? -1 : 1;
       } else {
         if (b.calculated_hours.isGreaterThan(a.calculated_hours)) {
           return -1;


### PR DESCRIPTION
Fixes #512

Changes:
The function responsible for selecting the inputs when creating transactions was improved. The new operation is based on the `ChooseSpends` function of the Skycoin node and the `ChooseSpendsMaximizeUxOuts` strategy:

https://github.com/skycoin/skycoin/blob/69e60c21c6873079e3fccee08db5658fec91f52e/src/wallet/wallet.go#L1926-L2022

https://github.com/skycoin/skycoin/blob/69e60c21c6873079e3fccee08db5658fec91f52e/src/wallet/wallet.go#L1850-L1856

The procedure follows the following steps:

- The unspent output with more coins is added to the transaction (if there is more than one output with the same number of coins, the one with the fewest hours is used)

- If it is necessary to add more coins, unspent outputs without hours are added (ordered from the one with the fewest coins to the one that has more) until having enough coins.

- If it is necessary to add more coins, unspent outputs with hours are added (ordered from the one with the fewest coins to the one that has more, if there is more than one output with the same number of coins, the one with the fewest hours is added first) until having enough coins.