### PR TITLE
Fix v0.24.0 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,14 @@ Run `npm start` for a dev server. Navigate to `http://localhost:4200/`.
 
 As this is a lite client, it requires a back-end to retrieve the blockchain state and inject new transactions. While using
 a dev build, the wallet tries to connect to a Skycoin node running locally, which must be started with the `-disable-csrf`
-option. The production builds connects to a public node set up at `https://node.skycoin.net`.
+option. The production builds connects to a public node set up at `https://node.skycoin.net`. The user can connect the wallet
+to another backend by entering its URL.
+
+### Minimum back-end version
+
+The wallet is currently compatible with nodes running v0.24.0 and above. As it is not possible to recover the number of active
+decimals in version 0.24.0, the wallet assumes that it is 6. The same happens with burn rate, so it is assumed to be 50%.
+Because of this, it is advisable to connect to a node running v0.25.0 or higher.
 
 ## Multi-coin compatibility
 

--- a/src/app/components/pages/settings/nodes/change-url/change-node-url.component.html
+++ b/src/app/components/pages/settings/nodes/change-url/change-node-url.component.html
@@ -7,7 +7,7 @@
   </div>
   <div class="property-container" *ngIf="!showingUrlForm">
     <h4>{{ 'nodes.change.node-properties' | translate}}</h4>
-    <div class="data">
+    <div class="data" *ngIf="coinName">
       <span>{{ 'nodes.change.coin-name' | translate }}:</span> <span>{{ coinName }}</span>
     </div>
     <div class="data">

--- a/src/app/components/pages/settings/nodes/change-url/change-node-url.component.ts
+++ b/src/app/components/pages/settings/nodes/change-url/change-node-url.component.ts
@@ -72,8 +72,6 @@ export class ChangeNodeURLComponent implements OnInit, OnDestroy {
       this.verificationSubscription = this.http.get(this.newUrl + '/api/v1/health').subscribe((response: any) => {
         this.nodeVersion = response.version.version;
         this.lastBlock = response.blockchain.head.seq;
-        this.hoursBurnRate = new BigNumber(100).dividedBy(response.user_verify_transaction.burn_factor).decimalPlaces(3, BigNumber.ROUND_FLOOR).toString() + '%';
-        this.coinName = response.coin;
 
         if (!isEqualOrSuperiorVersion(this.nodeVersion, '0.24.0')) {
           this.cancelChange(true, false);
@@ -81,6 +79,14 @@ export class ChangeNodeURLComponent implements OnInit, OnDestroy {
         } else if (response.csrf_enabled) {
           this.cancelChange(false, true);
           return;
+        }
+
+        if (isEqualOrSuperiorVersion(this.nodeVersion, '0.25.0')) {
+          this.hoursBurnRate = new BigNumber(100).dividedBy(response.user_verify_transaction.burn_factor).decimalPlaces(3, BigNumber.ROUND_FLOOR).toString() + '%';
+          this.coinName = response.coin;
+        } else {
+          this.hoursBurnRate = '50%';
+          this.coinName = null;
         }
 
         this.actionButton.resetState();

--- a/src/app/services/blockchain.service.ts
+++ b/src/app/services/blockchain.service.ts
@@ -11,6 +11,7 @@ import { ConnectionError } from '../enums/connection-error.enum';
 import { CoinService } from './coin.service';
 import { environment } from '../../environments/environment';
 import { GlobalsService } from './globals.service';
+import { isEqualOrSuperiorVersion } from '../utils/semver';
 
 export enum ProgressStates {
   Progress,
@@ -123,7 +124,11 @@ export class BlockchainService {
       .flatMap(() => this.apiService.get('health'))
       .map ((response: any) => {
         this.globalsService.setNodeVersion(response.version.version);
-        this.maxDecimals = response.user_verify_transaction.max_decimals;
+        if (isEqualOrSuperiorVersion(response.version.version, '0.25.0')) {
+          this.maxDecimals = response.user_verify_transaction.max_decimals;
+        } else {
+          this.maxDecimals = 6;
+        }
       });
   }
 }


### PR DESCRIPTION
Changes:
- This PR fixes 2 problems when connecting to a v0.24.0 node. The first one is that the initial connection procedure failed, because node v0.24.x does not return the `maxDecimals` parameter when calling the `health` endpoint. The second one is that when changing the node URL, if that node is v0.24.x, the operation failed, because the `health` endpoint does not return the `burn_factor` and `coin` parameters.
- Information about the minimum version that a node must have in order to use it as a backend was added to the README.
