### PR TITLE
Use a generic date format on the UI

### DIFF
--- a/src/app/components/pages/history/history.component.html
+++ b/src/app/components/pages/history/history.component.html
@@ -14,7 +14,7 @@
           <div class="-address">
             <h4 *ngIf="transaction.balance < 0 && transaction.confirmed">
               {{ 'history.sent' | translate }} {{ currentCoin.coinSymbol }}
-              <span class="-timestamp">{{ transaction.timestamp * 1000 | date:'short' }}</span>
+              <span class="-timestamp">{{ transaction.timestamp | dateTime }}</span>
             </h4>
             <h4 *ngIf="transaction.balance < 0 && !transaction.confirmed">
               {{ 'history.sending' | translate }} {{ currentCoin.coinSymbol }}
@@ -22,7 +22,7 @@
             </h4>
             <h4 *ngIf="transaction.balance > 0 && transaction.confirmed">
               {{ 'history.received' | translate }}  {{ currentCoin.coinSymbol }}
-              <span class="-timestamp">{{ transaction.timestamp * 1000 | date:'short' }}</span>
+              <span class="-timestamp">{{ transaction.timestamp | dateTime }}</span>
             </h4>
             <h4 *ngIf="transaction.balance > 0 && !transaction.confirmed">
               {{ 'history.receiving' | translate }} {{ currentCoin.coinSymbol }}

--- a/src/app/components/pages/history/history.component.spec.ts
+++ b/src/app/components/pages/history/history.component.spec.ts
@@ -5,7 +5,7 @@ import { HistoryComponent } from './history.component';
 import { HistoryService } from '../../../services/wallet/history.service';
 import { PriceService } from '../../../services/price.service';
 import { CoinService } from '../../../services/coin.service';
-import { MockTranslatePipe, MockPriceService, MockCoinService, MockHistoryService, MockCustomMatDialogService } from '../../../utils/test-mocks';
+import { MockTranslatePipe, MockPriceService, MockCoinService, MockHistoryService, MockCustomMatDialogService, MockDateTimePipe } from '../../../utils/test-mocks';
 import { CustomMatDialogService } from '../../../services/custom-mat-dialog.service';
 
 describe('HistoryComponent', () => {
@@ -14,7 +14,7 @@ describe('HistoryComponent', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [ HistoryComponent, MockTranslatePipe ],
+      declarations: [ HistoryComponent, MockTranslatePipe, MockDateTimePipe ],
       providers: [
         { provide: HistoryService, useClass: MockHistoryService },
         { provide: PriceService, useClass: MockPriceService },

--- a/src/app/components/pages/send-skycoin/send-verify/transaction-info/transaction-info.component.html
+++ b/src/app/components/pages/send-skycoin/send-verify/transaction-info/transaction-info.component.html
@@ -22,7 +22,7 @@
             <span>{{ 'tx.id' | translate }}:</span> <span>{{ transaction.txid }}</span>
           </div>
           <div class="-data">
-            <span>{{ 'tx.date' | translate }}:</span> <span>{{ transaction.timestamp * 1000 | date:'short' }}</span>
+            <span>{{ 'tx.date' | translate }}:</span> <span>{{ transaction.timestamp | dateTime }}</span>
           </div>
           <div class="-data">
             <span>{{ 'tx.status' | translate }}:</span> <span>{{ transaction.confirmed ? ('tx.confirmed' | translate) : ('tx.pending' | translate) }}</span>

--- a/src/app/components/pages/send-skycoin/send-verify/transaction-info/transaction-info.component.spec.ts
+++ b/src/app/components/pages/send-skycoin/send-verify/transaction-info/transaction-info.component.spec.ts
@@ -4,7 +4,7 @@ import { NO_ERRORS_SCHEMA } from '@angular/core';
 import { TransactionInfoComponent } from './transaction-info.component';
 import { PriceService } from '../../../../../services/price.service';
 import { CoinService } from '../../../../../services/coin.service';
-import { MockTranslatePipe, MockPriceService, MockCoinService } from '../../../../../utils/test-mocks';
+import { MockTranslatePipe, MockPriceService, MockCoinService, MockDateTimePipe } from '../../../../../utils/test-mocks';
 
 describe('TransactionInfoComponent', () => {
   let component: TransactionInfoComponent;
@@ -12,7 +12,7 @@ describe('TransactionInfoComponent', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [ TransactionInfoComponent, MockTranslatePipe ],
+      declarations: [ TransactionInfoComponent, MockTranslatePipe, MockDateTimePipe ],
       schemas: [ NO_ERRORS_SCHEMA ],
       providers: [
         { provide: PriceService, useClass: MockPriceService },


### PR DESCRIPTION
Fixes #514 

Changes:
- The dates are now displayed with the `yyyy/MM/dd` format.

Implementation of https://github.com/skycoin/skycoin/pull/2115 for the web wallet.