### PR TITLE
Show the number of hours on the pending transactions screen

### DIFF
--- a/src/app/components/pages/settings/pending-transactions/pending-transactions.component.html
+++ b/src/app/components/pages/settings/pending-transactions/pending-transactions.component.html
@@ -9,16 +9,18 @@
     <div *ngIf="!!transactions && transactions.length > 0" class="-table">
       <div class="-headers">
         <div class="flex-fill -not-on-small-and-below">{{ 'pending-txs.txid' | translate }}</div>
+        <div class="-width-150 -not-on-small-and-below">{{ currentCoin.coinSymbol }}</div>
+        <div class="-width-150 -not-on-small-and-below">{{ currentCoin.hoursName }}</div>
         <div class="-width-150 -not-on-small-and-below">{{ 'pending-txs.timestamp' | translate }}</div>
-        <div class="-width-150 -coins -not-on-small-and-below">{{ currentCoin.coinSymbol }}</div>
         <div class="flex-fill -on-small-and-below-only">{{ 'pending-txs.transactions' | translate }}</div>
       </div>
       <div class="-paper">
         <ng-container *ngIf="transactions.length">
           <div class="-row -not-on-small-and-below" *ngFor="let transaction of transactions">
             <div class="flex-fill -txid">{{ transaction.txid }}</div>
-            <div class="-width-150">{{ transaction.timestamp | dateTime }}</div>
-            <div class="-width-150 -coins">{{ (transaction.amount ? transaction.amount.decimalPlaces(6).toString() : 0) | number:'1.0-6' }}</div>
+            <div class="-width-150">{{ (transaction.amount ? transaction.amount.decimalPlaces(6).toString() : 0) | number:'1.0-6' }}</div>
+            <div class="-width-150">{{ (transaction.hours ? transaction.hours.decimalPlaces(0).toString() : 0) | number:'1.0-0' }}</div>
+            <div class="-width-150 -timestamp">{{ transaction.timestamp | dateTime }}</div>
           </div>
           <div class="-row -on-small-and-below-only" *ngFor="let transaction of transactions">
             <div class="small-screen-list-container">
@@ -27,12 +29,16 @@
                 <div class="-break-all">{{ transaction.txid }}</div>
               </div>
               <div class="list-row">
-                <div class="element-label">{{ 'pending-txs.timestamp' | translate }}:</div>
-                <div class="-one-line-ellipsis">{{ transaction.timestamp | dateTime }}</div>
-              </div>
-              <div class="list-row">
                 <div class="element-label">{{ currentCoin.coinSymbol }}:</div>
                 <div class="-one-line-ellipsis">{{ (transaction.amount ? transaction.amount.decimalPlaces(6).toString() : 0) | number:'1.0-6' }}</div>
+              </div>
+              <div class="list-row">
+                <div class="element-label">{{ currentCoin.hoursName }}:</div>
+                <div class="-one-line-ellipsis">{{ (transaction.hours ? transaction.hours.decimalPlaces(0).toString() : 0) | number:'1.0-0' }}</div>
+              </div>
+              <div class="list-row">
+                <div class="element-label">{{ 'pending-txs.timestamp' | translate }}:</div>
+                <div class="-one-line-ellipsis">{{ transaction.timestamp | dateTime }}</div>
               </div>
             </div>
           </div>

--- a/src/app/components/pages/settings/pending-transactions/pending-transactions.component.scss
+++ b/src/app/components/pages/settings/pending-transactions/pending-transactions.component.scss
@@ -4,6 +4,6 @@
   word-break: break-all;
 }
 
-.-coins {
-  text-align: right;
+.-timestamp {
+  color: $grey;
 }

--- a/src/app/components/pages/settings/pending-transactions/pending-transactions.component.ts
+++ b/src/app/components/pages/settings/pending-transactions/pending-transactions.component.ts
@@ -85,7 +85,12 @@ export class PendingTransactionsComponent implements OnInit, OnDestroy {
     })
       .map(transaction => {
         transaction.amount = new BigNumber('0');
-        transaction.outputs.map(output => transaction.amount = transaction.amount.plus(output.coins));
+        transaction.hours = new BigNumber('0');
+        transaction.outputs.map(output => {
+          transaction.amount = transaction.amount.plus(output.coins);
+          transaction.hours = transaction.hours.plus(output.hours);
+        });
+
         return transaction;
       });
   }


### PR DESCRIPTION
Fixes #511 

Changes:
- Now the pending transactions page shows the number of hours, in a way similar to how the desktop wallet does it.
