### PR TITLE
Show the Coin Hours in the simple form

### DIFF
--- a/src/app/components/pages/send-skycoin/send-form/send-form.component.html
+++ b/src/app/components/pages/send-skycoin/send-form/send-form.component.html
@@ -8,6 +8,7 @@
                 [disabled]="!wallet.balance || wallet.balance.isLessThanOrEqualTo(0)"
                 [ngValue]="wallet">
           {{ wallet.label }} — {{ (wallet.balance ? wallet.balance.decimalPlaces(6).toString() : 0) | number:'1.0-6' }} {{ currentCoin.coinSymbol }}
+          ({{ wallet.hours.decimalPlaces(0).toString() | number:'1.0-0' }} {{ currentCoin.hoursName }})
         </option>
       </select>
     </div>


### PR DESCRIPTION
Fixes #523 

Changes:
- With this PR now the Select that allows to select the wallet in the form for sending coins also shows the Coin Hours balance.

Implementation of https://github.com/skycoin/skycoin/pull/2157 for the web wallet.