### PR TITLE
Show a warning while the wallet is synchronizing

### DIFF
--- a/src/app/components/layout/header/header.component.html
+++ b/src/app/components/layout/header/header.component.html
@@ -57,7 +57,14 @@
       {{ 'header.errors.no-backend3' | translate }}
     </div>
   </mat-toolbar>
-  <mat-toolbar class="notification-bar" *ngIf="hasPendingTxs">
-    <div>{{ 'header.pending-txs1' | translate }} <a routerLink="/settings/pending-transactions">{{ 'header.pending-txs2' | translate }}</a> {{ 'header.pending-txs3' | translate }}</div>
+  <mat-toolbar class="notification-bar" *ngIf="hasPendingTxs || !synchronized">
+    <div *ngIf="hasPendingTxs && synchronized">
+      {{ 'header.pending-txs1' | translate }}
+      <a routerLink="/settings/pending-transactions">{{ 'header.pending-txs2' | translate }}</a>
+      {{ 'header.pending-txs3' | translate }}
+    </div>
+    <div *ngIf="!synchronized">
+      {{ 'header.synchronizing' | translate }}
+    </div>
   </mat-toolbar>
 </div>

--- a/src/app/components/pages/send-skycoin/send-form/send-form.component.ts
+++ b/src/app/components/pages/send-skycoin/send-form/send-form.component.ts
@@ -10,8 +10,8 @@ import { Observable } from 'rxjs/Observable';
 import { WalletService } from '../../../../services/wallet/wallet.service';
 import { SpendingService } from '../../../../services/wallet/spending.service';
 import { ButtonComponent } from '../../../layout/button/button.component';
-import { Wallet } from '../../../../app.datatypes';
-import { openUnlockWalletModal } from '../../../../utils/index';
+import { Wallet, ConfirmationData } from '../../../../app.datatypes';
+import { openUnlockWalletModal, showConfirmationModal } from '../../../../utils/index';
 import { BaseCoin } from '../../../../coins/basecoin';
 import { CoinService } from '../../../../services/coin.service';
 import { BlockchainService } from '../../../../services/blockchain.service';
@@ -42,7 +42,7 @@ export class SendFormComponent implements OnInit, OnDestroy {
     private walletService: WalletService,
     private spendingService: SpendingService,
     private snackbar: MatSnackBar,
-    private unlockDialog: CustomMatDialogService,
+    private dialog: CustomMatDialogService,
     private coinService: CoinService,
     private blockchainService: BlockchainService
   ) {}
@@ -83,11 +83,36 @@ export class SendFormComponent implements OnInit, OnDestroy {
     if (!wallet.seed) {
       this.removeProcessSubscription();
 
-      this.processSubscription = openUnlockWalletModal(wallet, this.unlockDialog).componentInstance
-        .onWalletUnlocked.first().subscribe(() => this.createTransaction(wallet));
+      this.processSubscription = openUnlockWalletModal(wallet, this.dialog).componentInstance
+        .onWalletUnlocked.first().subscribe(() => this.checkBeforeSending());
     } else {
-      this.createTransaction(wallet);
+      this.checkBeforeSending();
     }
+  }
+
+  private checkBeforeSending() {
+    this.blockchainService.synchronized.first().subscribe(synchronized => {
+      if (synchronized) {
+        this.createTransaction(this.form.value.wallet);
+      } else {
+        this.showSynchronizingWarning();
+      }
+    });
+  }
+
+  private showSynchronizingWarning() {
+    const confirmationData: ConfirmationData = {
+      text: 'send.synchronizing-warning',
+      headerText: 'confirmation.header-text',
+      confirmButtonText: 'confirmation.confirm-button',
+      cancelButtonText: 'confirmation.cancel-button',
+    };
+
+    showConfirmationModal(this.dialog, confirmationData).afterClosed().subscribe(confirmationResult => {
+      if (confirmationResult) {
+        this.createTransaction(this.form.value.wallet);
+      }
+    });
   }
 
   private createTransaction(wallet: Wallet) {

--- a/src/app/services/blockchain.service.ts
+++ b/src/app/services/blockchain.service.ts
@@ -29,6 +29,7 @@ export class ProgressEvent {
 @Injectable()
 export class BlockchainService {
   private progressSubject: BehaviorSubject<ProgressEvent> = new BehaviorSubject<ProgressEvent>(null);
+  private synchronizedSubject: BehaviorSubject<any> = new BehaviorSubject<boolean>(false);
   private connectionsSubscription: Subscription;
   private maxDecimals = 6;
   private readonly defaultPeriod = 90000;
@@ -36,6 +37,10 @@ export class BlockchainService {
 
   get progress(): Observable<ProgressEvent> {
     return this.progressSubject.asObservable();
+  }
+
+  get synchronized() {
+    return this.synchronizedSubject.asObservable();
   }
 
   get currentMaxDecimals(): number {
@@ -71,6 +76,7 @@ export class BlockchainService {
 
     this.globalsService.setNodeVersion(null);
     this.progressSubject.next({ state: ProgressStates.Restarting });
+    this.synchronizedSubject.next(false);
 
     this.connectionsSubscription = this.checkConnectionState()
       .subscribe(
@@ -105,6 +111,7 @@ export class BlockchainService {
         response.highest - response.current <= 5 ? this.shortPeriod : this.defaultPeriod
       );
     } else {
+      this.synchronizedSubject.next(true);
       this.balanceService.startGettingBalances();
     }
   }

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -45,6 +45,7 @@
     "syncing-blocks": "Syncing blocks",
     "update1": "Wallet update",
     "update2": "available.",
+    "synchronizing": "The node is synchronizing. Data you see may not be updated.",
     "pending-txs1": "There are some",
     "pending-txs2": "pending transactions.",
     "pending-txs3": "Data you see may not be updated.",
@@ -203,6 +204,7 @@
   },
 
   "send": {
+    "synchronizing-warning": "The node is still synchronizing the data, so the balance shown may be incorrect. Are you sure you want to continue?",
     "from-label": "Send from",
     "to-label": "Send to",
     "amount-label": "Amount",

--- a/src/assets/i18n/es.json
+++ b/src/assets/i18n/es.json
@@ -45,6 +45,7 @@
     "syncing-blocks": "Sincronizando bloques",
     "update1": "La actualización",
     "update2": "está disponible.",
+    "synchronizing": "El nodo está sincronizando. Los datos mostrados pueden estar desactualizados",
     "pending-txs1": "Hay una o más",
     "pending-txs2": "transacciones pendientes.",
     "pending-txs3": "Los datos mostrados pueden estar desactualizados.",
@@ -202,6 +203,7 @@
   },
 
   "send": {
+    "synchronizing-warning": "El nodo todavía está sincronizando los datos, por lo que el saldo que se muestra puede ser incorrecto. ¿Seguro de que desea continuar?",
     "from-label": "Enviar desde",
     "to-label": "Enviar a",
     "amount-label": "Cantidad",


### PR DESCRIPTION
Fixes #515 

Changes:
- A warning is displayed while the database is still being synchronized.
- If the user attempts to send a transaction while the database is being synchronized, a warning is displayed and confirmation is requested.

Implementation of https://github.com/skycoin/skycoin/pull/2112 and https://github.com/skycoin/skycoin/pull/2145 for the web wallet.