### PR TITLE
Improved transactions processing in the history

### DIFF
--- a/src/app/app.datatypes.ts
+++ b/src/app/app.datatypes.ts
@@ -30,6 +30,7 @@ export class Transaction {
   outputs: any[];
   hoursSent?: BigNumber;
   hoursBurned?: BigNumber;
+  coinsMovedInternally?: boolean;
 }
 
 export class NormalTransaction extends Transaction {

--- a/src/app/components/pages/history/history.component.html
+++ b/src/app/components/pages/history/history.component.html
@@ -44,27 +44,39 @@
       *ngIf="!transactions || transactions.length === 0"></app-loading-content>
     <div *ngIf="!!transactions && transactions.length > 0" class="-paper">
       <ng-container *ngFor="let transaction of transactions">
-        <div class="-transaction" *ngIf="transaction.balance !== 0" (click)="showTransaction(transaction)">
-          <div class="-icon" [ngClass]="{ '-incoming': transaction.balance > 0, '-pending': !transaction.confirmed }">
+        <div class="-transaction" (click)="showTransaction(transaction)">
+          <div class="-icon" [ngClass]="{ '-incoming': transaction.balance.isGreaterThan(0) && !transaction.coinsMovedInternally, '-pending': !transaction.confirmed }">
             <img src="assets/img/send-blue.png">
           </div>
           <div class="-address">
-            <h4 *ngIf="transaction.balance < 0 && transaction.confirmed">
-              {{ 'history.sent' | translate }} {{ currentCoin.coinSymbol }}
-              <span class="-timestamp">{{ transaction.timestamp | dateTime }}</span>
-            </h4>
-            <h4 *ngIf="transaction.balance < 0 && !transaction.confirmed">
-              {{ 'history.sending' | translate }} {{ currentCoin.coinSymbol }}
-              <span class="-pending">{{ 'history.pending' | translate }}</span>
-            </h4>
-            <h4 *ngIf="transaction.balance > 0 && transaction.confirmed">
-              {{ 'history.received' | translate }}  {{ currentCoin.coinSymbol }}
-              <span class="-timestamp">{{ transaction.timestamp | dateTime }}</span>
-            </h4>
-            <h4 *ngIf="transaction.balance > 0 && !transaction.confirmed">
-              {{ 'history.receiving' | translate }} {{ currentCoin.coinSymbol }}
-              <span class="-pending">{{ 'history.pending' | translate }}</span>
-            </h4>
+            <ng-container *ngIf="!transaction.coinsMovedInternally">
+              <h4 *ngIf="transaction.balance.isLessThan(0) && transaction.confirmed">
+                {{ 'history.sent' | translate }} {{ currentCoin.coinSymbol }}
+                <span class="-timestamp">{{ transaction.timestamp | dateTime }}</span>
+              </h4>
+              <h4 *ngIf="transaction.balance.isLessThan(0) && !transaction.confirmed">
+                {{ 'history.sending' | translate }} {{ currentCoin.coinSymbol }}
+                <span class="-pending">{{ 'history.pending' | translate }}</span>
+              </h4>
+              <h4 *ngIf="transaction.balance.isGreaterThan(0) && transaction.confirmed">
+                {{ 'history.received' | translate }}  {{ currentCoin.coinSymbol }}
+                <span class="-timestamp">{{ transaction.timestamp | dateTime }}</span>
+              </h4>
+              <h4 *ngIf="transaction.balance.isGreaterThan(0) && !transaction.confirmed">
+                {{ 'history.receiving' | translate }} {{ currentCoin.coinSymbol }}
+                <span class="-pending">{{ 'history.pending' | translate }}</span>
+              </h4>
+            </ng-container>
+            <ng-container *ngIf="transaction.coinsMovedInternally">
+              <h4 *ngIf="transaction.confirmed">
+                {{ 'history.moved' | translate }} {{ currentCoin.coinSymbol }}
+                <span class="-timestamp">{{ transaction.timestamp | dateTime }}</span>
+              </h4>
+              <h4 *ngIf="!transaction.confirmed">
+                {{ 'history.moving' | translate }} {{ currentCoin.coinSymbol }}
+                <span class="-pending">{{ 'history.pending' | translate }}</span>
+              </h4>
+            </ng-container>
             <div class="-detail" *ngFor="let address of transaction.addresses">
               <div>
                 <img class="qr-code-button -not-on-small-and-below" src="assets/img/qr-code-black.png" (click)="showQr($event, address)">

--- a/src/app/components/pages/send-skycoin/send-verify/transaction-info/transaction-info.component.html
+++ b/src/app/components/pages/send-skycoin/send-verify/transaction-info/transaction-info.component.html
@@ -31,7 +31,7 @@
         <div class="-data">
           <span>{{ 'tx.hours' | translate }}:</span>
           <span *ngIf="transaction.hoursSent">
-            {{ transaction.hoursSent.decimalPlaces(0).toString() | number:'1.0-0' }} {{ !isPreview && transaction.balance.isGreaterThan(0) ? ('tx.hours-received' | translate) : ('tx.hours-sent' | translate) }}
+            {{ transaction.hoursSent.decimalPlaces(0).toString() | number:'1.0-0' }} {{ hoursText | translate }}
             |
             {{ transaction.hoursBurned.decimalPlaces(0).toString() | number:'1.0-0' }} {{ 'tx.hours-burned' | translate }}
           </span>
@@ -43,7 +43,7 @@
       </div>
 
       <ng-template #priceContents>
-        <div class="-icon" [ngClass]="{ '-incoming': !isPreview && transaction.balance && transaction.balance.isGreaterThan(0) }">
+        <div class="-icon" [ngClass]="{ '-incoming': !isPreview && transaction.balance && transaction.balance.isGreaterThan(0) && !transaction.coinsMovedInternally }">
           <img src="assets/img/send-blue.png">
         </div>
         <h4 *ngIf="transaction.balance">{{ transaction.balance.decimalPlaces(6).toString() | number:'1.0-6' }} {{ currentCoin.coinSymbol }}</h4>

--- a/src/app/components/pages/send-skycoin/send-verify/transaction-info/transaction-info.component.ts
+++ b/src/app/components/pages/send-skycoin/send-verify/transaction-info/transaction-info.component.ts
@@ -25,6 +25,22 @@ export class TransactionInfoComponent implements OnInit, OnDestroy {
     private coinService: CoinService
   ) {}
 
+  get hoursText(): string {
+    if (!this.transaction) {
+      return '';
+    }
+
+    if (!this.isPreview) {
+      if ((this.transaction as any).coinsMovedInternally) {
+        return 'tx.hours-moved';
+      } else if (this.transaction.balance.isGreaterThan(0)) {
+        return 'tx.hours-received';
+      }
+    }
+
+    return 'tx.hours-sent';
+  }
+
   ngOnInit() {
     this.subscription = this.priceService.price
       .subscribe(price => this.price = price);

--- a/src/app/services/wallet/history.service.spec.ts
+++ b/src/app/services/wallet/history.service.spec.ts
@@ -73,7 +73,7 @@ describe('HistoryService', () => {
       const apiResponse = createAddressTransactions(ownerAddress.address, destinationAddress, 13);
       spyApiService.get.and.returnValue( Observable.of([apiResponse]) );
 
-      const expectedTransaction: NormalTransaction = createTransaction([destinationAddress], ownerAddress.address, destinationAddress, 13, new BigNumber(-13));
+      const expectedTransaction: NormalTransaction = createTransaction([ownerAddress.address], ownerAddress.address, destinationAddress, 13, new BigNumber(-13));
       expectedTransaction['hoursSent'] = new BigNumber(NaN);
       expectedTransaction['hoursBurned'] = new BigNumber(NaN);
 

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -227,6 +227,7 @@
     "hours": "Hours",
     "id": "Tx ID",
     "show-more": "Show more",
+    "hours-moved": "moved",
     "hours-sent": "sent",
     "hours-received": "received",
     "hours-burned": "burned",
@@ -302,6 +303,8 @@
 
   "history": {
     "tx-detail": "Transaction Detail",
+    "moving": "Internally moving",
+    "moved": "Internally moved",
     "sending": "Sending",
     "sent": "Sent",
     "received": "Received",

--- a/src/assets/i18n/es.json
+++ b/src/assets/i18n/es.json
@@ -226,6 +226,7 @@
     "hours": "Horas",
     "id": "Tx ID",
     "show-more": "Mostrar más",
+    "hours-moved": "movida(s)",
     "hours-sent": "enviada(s)",
     "hours-received": "recibida(s)",
     "hours-burned": "quemada(s)",
@@ -301,6 +302,8 @@
 
   "history": {
     "tx-detail": "Detalles de la Transacción",
+    "moving": "Moviendo internamente",
+    "moved": "Movida internamente",
     "sending": "Enviando",
     "sent": "Enviada",
     "received": "Recibida",


### PR DESCRIPTION
Fixes #522 

Changes:
- When coins were moved between wallet addresses, the history showed that the user sended as many coins as there were in the inputs. Now that case is treated differently, and the UI shows `Internally moved`, instead of `Sent` or `Received`.

Implementation of https://github.com/skycoin/skycoin/pull/2147 for the web wallet.