### PR TITLE
Change the warning icon position

### DIFF
--- a/src/app/components/pages/wallets/create-wallet/create-wallet-form/create-wallet-form.component.scss
+++ b/src/app/components/pages/wallets/create-wallet/create-wallet-form/create-wallet-form.component.scss
@@ -80,7 +80,6 @@ label[for=seed] {
 .-alert-box {
   background-color: #ffdede;
   padding: 15px;
-  align-items: center;
   margin-bottom: 20px;
 
   @media (min-width: $max-very-small-width+1) {
@@ -97,11 +96,16 @@ label[for=seed] {
         position: relative;
         top: -5px;
       }
+
+      mat-icon {
+        margin-top: 0px;
+      }
     }
   }
 
   mat-icon {
     margin-right: 10px;
+    margin-top: 5px;
     animation: blink 1s linear infinite;
   }
 


### PR DESCRIPTION
Changes:
- The warning icon is now at the top of the warning boxes, instead of the middle. This should help to have a greater consistency in the UI.

This is the web wallet equivalent of  https://github.com/skycoin/skycoin/pull/2256