### PR TITLE
Deactivate the custom URLs for the nodes

### DIFF
--- a/.angular-cli.json
+++ b/.angular-cli.json
@@ -30,6 +30,8 @@
       "environments": {
         "dev": "environments/environment.ts",
         "prod": "environments/environment.prod.ts",
+        "local": "environments/environment.local.ts",
+        "local-prod": "environments/environment.local.prod.ts",
         "e2e": "environments/environment.e2e.ts",
         "e2e-prod": "environments/environment.e2e-prod.ts"
       }

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,9 @@
 build:
 	npm run build
 
+build-for-electron: ## compiles a version to be used with Electron
+	npm run build-for-local-fs
+
 build-for-local-fs: ## compiles a version to be used from the local file system
 	npm run build-for-local-fs
 

--- a/electron/README.md
+++ b/electron/README.md
@@ -42,7 +42,7 @@ Before building the application, the `dist` folder must be updated. To update it
 the following command:
 
 ```sh
-make build
+make build-for-electron
 ```
 
 Additionally, it is necessary to compile the content server first. You can do it by running, from the `./electron` folder, the

--- a/package.json
+++ b/package.json
@@ -5,9 +5,11 @@
   "scripts": {
     "ng": "ng",
     "start": "ng serve --proxy-config proxy.config.js --delete-output-path false --host 0.0.0.0",
+    "start-local": "ng serve --proxy-config proxy.config.js --delete-output-path false --host 0.0.0.0 --environment local",
     "build": "ng build --prod",
     "build-dev": "ng build",
-    "build-for-local-fs": "ng build --prod --base-href ./index.html",
+    "build-for-electron": "ng build --prod --environment local-prod",
+    "build-for-local-fs": "ng build --prod --environment local-prod --base-href ./index.html",
     "lint": "ng lint",
     "e2e": "ng e2e --proxy-config proxy.config.js --environment e2e --delete-output-path false --suite dev",
     "e2e-prod": "ng e2e --prod --proxy-config proxy.config.js --environment e2e-prod --delete-output-path false --suite prod",

--- a/src/app/components/pages/settings/nodes/nodes.component.html
+++ b/src/app/components/pages/settings/nodes/nodes.component.html
@@ -19,7 +19,7 @@
             <i class="material-icons -custom-url-icon" [matTooltip]="'nodes.custom-label' | translate">announcement</i>
             <span [attr.title]="customNodeUrls[coin.id.toString()]">{{ customNodeUrls[coin.id.toString()] }}</span>
           </div>
-          <div class="-width-150 -text-right">
+          <div *ngIf="enableCustomNodes" class="-width-150 -text-right">
             <span class="-link" (click)="changeNodeURL(coin)">{{ 'nodes.change-url' | translate }}</span>
           </div>
         </div>

--- a/src/app/components/pages/settings/nodes/nodes.component.ts
+++ b/src/app/components/pages/settings/nodes/nodes.component.ts
@@ -5,6 +5,7 @@ import { CoinService } from '../../../../services/coin.service';
 import { BaseCoin } from '../../../../coins/basecoin';
 import { ChangeNodeURLComponent } from './change-url/change-node-url.component';
 import { CustomMatDialogService } from '../../../../services/custom-mat-dialog.service';
+import { environment } from '../../../../../environments/environment';
 
 @Component({
   selector: 'app-nodes',
@@ -12,9 +13,9 @@ import { CustomMatDialogService } from '../../../../services/custom-mat-dialog.s
   styleUrls: ['./nodes.component.scss'],
 })
 export class NodesComponent implements OnInit {
-
   coins: BaseCoin[];
   customNodeUrls: object;
+  enableCustomNodes = environment.enableCustomNodes;
 
   constructor(
     private coinService: CoinService,

--- a/src/environments/environment.e2e-prod.ts
+++ b/src/environments/environment.e2e-prod.ts
@@ -1,4 +1,5 @@
 export const environment = {
   production: true,
   e2eTest: true,
+  enableCustomNodes: false,
 };

--- a/src/environments/environment.e2e.ts
+++ b/src/environments/environment.e2e.ts
@@ -1,4 +1,5 @@
 export const environment = {
   production: false,
   e2eTest: true,
+  enableCustomNodes: false,
 };

--- a/src/environments/environment.local.prod.ts
+++ b/src/environments/environment.local.prod.ts
@@ -1,5 +1,5 @@
 export const environment = {
-  production: false,
+  production: true,
   e2eTest: false,
-  enableCustomNodes: false,
+  enableCustomNodes: true,
 };

--- a/src/environments/environment.local.ts
+++ b/src/environments/environment.local.ts
@@ -1,5 +1,5 @@
 export const environment = {
   production: false,
   e2eTest: false,
-  enableCustomNodes: false,
+  enableCustomNodes: true,
 };

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -1,4 +1,5 @@
 export const environment = {
   production: true,
   e2eTest: false,
+  enableCustomNodes: false,
 };


### PR DESCRIPTION
Changes:
- Deactivates the option for changing the node URL in the nodes page. This does not happens if the wallet was compiled for being used from the local file system or Electron.
