### PR TITLE
Fixes for the option of using custom nodes in the Electron version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,4 +44,3 @@ debug.log
 # System Files
 .DS_Store
 Thumbs.db
-electron/nodes.snd

--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,4 @@ debug.log
 # System Files
 .DS_Store
 Thumbs.db
+electron/nodes.snd

--- a/MULTICOIN-INFO.md
+++ b/MULTICOIN-INFO.md
@@ -40,6 +40,13 @@ Once the class is created and the image files are added, it is necessary to add 
 class in the [CoinService.coins](src/app/services/coin.service.ts) array. That must be done in the
 `CoinService.loadAvailableCoins` function.
 
+After that, you must add the host name of the coin node to the `defaultCoinHosts` array, inside
+[electron/src/electron-main.js](electron/src/electron-main.js). For example, if the node is in
+`https://node.skycoin.net`, you must add a new entry with `node.skycoin.net`.
+
+To finish, add the node URL (`https://node.skycoin.net`, for example) in the `connect-src` section of the
+`Content-Security-Policy` header defined in [docker/images/nginx.conf](docker/images/nginx.conf).
+
 ## Additional information about the header images
 
 The image indicated in `imageName` is the one that will be shown in the upper part of the wallet, as the background

--- a/electron/server.go
+++ b/electron/server.go
@@ -32,7 +32,7 @@ var (
 // ContentSecurityPolicy csp header in http response
 const ContentSecurityPolicy = "default-src 'self'" +
 	"; worker-src 'self' blob:" +
-	"; connect-src 'self' https://api.coinpaprika.com https://node.skycoin.net" +
+	"; connect-src *" +
 	"; img-src 'self' 'unsafe-inline' data:" +
 	"; style-src 'self' 'unsafe-inline'" +
 	"; object-src	'none'" +

--- a/electron/src/electron-main.js
+++ b/electron/src/electron-main.js
@@ -236,8 +236,9 @@ function createWindow() {
   });
 }
 
+const customNodeUrlsFilePath = path.join(app.getPath('appData'), './Skycoin');
 // File with the info about the custom node URLs added by the user.
-const customNodeUrlsFile = './nodes.snd'
+const customNodeUrlsFile = path.join(customNodeUrlsFilePath, './custom-nodes.snd');
 
 // Load, from customNodeUrlsFile, the custom node URLs added by the user and add them to the URL whitelist.
 ipcMain.on('loadNodeUrlsSync', (event) => {
@@ -311,6 +312,10 @@ ipcMain.on('removeTemporarilyAllowedCoinSync', (event) => {
 
 // Adds a temporarily allowed coin to customNodeUrlsFile, so its URL can be accesses in future sessions.
 ipcMain.on('acceptTemporarilyAllowedCoinSync', (event) => {
+  if (coinsWithAllowedNodes.has(temporarilyAllowedCoin['id'] + '')) {
+    allowedNodes.delete(url.parse(coinsWithAllowedNodes.get(temporarilyAllowedCoin['id'] + '')).host);
+  }
+
   coinsWithAllowedNodes.set(temporarilyAllowedCoin['id'] + '', temporarilyAllowedCoin['url']);
   allowedNodes.set(temporarilyAllowedCoin['host'], true);
 
@@ -326,6 +331,10 @@ function saveNodeUrls() {
   coinsWithAllowedNodes.forEach((val, key) => {
     data[key] = val;
   });
+
+  if (!fs.existsSync(customNodeUrlsFilePath)) {
+    fs.mkdirSync(customNodeUrlsFilePath, { recursive: true });
+  }
 
   fs.writeFileSync(customNodeUrlsFile, JSON.stringify(data), 'utf8');
 }

--- a/electron/src/electron-main.js
+++ b/electron/src/electron-main.js
@@ -4,6 +4,7 @@ const { app, Menu, BrowserWindow, shell, session, dialog, ipcMain } = require('e
 const childProcess = require('child_process');
 const path = require('path')
 const url = require('url');
+const fs = require('fs');
 
 global.eval = function() { throw new Error('bad!!'); }
 
@@ -22,7 +23,7 @@ app.setAsDefaultProtocolClient('skycoin');
 // be closed automatically when the JavaScript object is garbage collected.
 let win;
 
-var server = null;
+let server = null;
 const serverPort= 8412;
 
 // It is only possible to make connections to hosts that are in this lists.
@@ -33,7 +34,13 @@ allowedHosts.set('api.github.com', true);
 if (dev) {
   allowedHosts.set('localhost:4200', true);
 }
-var allowedNodes = new Map();
+
+var defaultCoinHosts = new Map();
+defaultCoinHosts.set('node.skycoin.net', true);
+
+let allowedNodes = new Map();
+let coinsWithAllowedNodes = new Map();
+let temporarilyAllowedCoin;
 
 function startServer() {
   if (!dev) {
@@ -220,7 +227,7 @@ function createWindow() {
       }
 
       let requestHost = url.parse(requestUrl).host;
-      if (!allowedHosts.has(requestHost) && !allowedNodes.has(requestHost)) {
+      if (!allowedHosts.has(requestHost) && !allowedNodes.has(requestHost) && !defaultCoinHosts.has(requestHost) && (!temporarilyAllowedCoin || temporarilyAllowedCoin.host !== requestHost)) {
         callback({cancel: true})
         return;
       }
@@ -229,13 +236,99 @@ function createWindow() {
   });
 }
 
-// Gets the URLs of the nodes of all the coins and adds the hosts to allowedNodes, so that it is
-// possible to connect with them.
-ipcMain.on('setNodesUrls', (event, list) => {
-  allowedNodes = new Map();
-  list.forEach(value => allowedNodes.set(url.parse(value).host, true));
+// File with the info about the custom node URLs added by the user.
+const customNodeUrlsFile = './nodes.snd'
+
+// Load, from customNodeUrlsFile, the custom node URLs added by the user and add them to the URL whitelist.
+ipcMain.on('loadNodeUrlsSync', (event) => {
+  let rawData;
+  let data;
+
+  if (fs.existsSync(customNodeUrlsFile)) {
+    rawData = fs.readFileSync(customNodeUrlsFile, 'utf8');
+  } else {
+    rawData = '{}';
+  }
+
+  data = JSON.parse(rawData);
+
+  for (var key in data) {
+    coinsWithAllowedNodes.set(key + '', data[key]);
+    allowedNodes.set(url.parse(data[key]).host, true);
+  }
+
+  event.returnValue = rawData;
+});
+
+// Removes a coin from customNodeUrlsFile an the URL whitelist.
+ipcMain.on('removeAllowedCoinSync', (event, id) => {
+  if (coinsWithAllowedNodes.has(id + '')) {
+    allowedNodes.delete(url.parse(coinsWithAllowedNodes.get(id + '')).host);
+    coinsWithAllowedNodes.delete(id + '');
+    saveNodeUrls();
+  }
+
   event.returnValue = null;
 });
+
+// Temporarily adds a coin to the URL whitelist, but not to customNodeUrlsFile.
+ipcMain.on('temporarilyAllowCoinSync', (event, data) => {
+  const coinHost = url.parse(data.url).host;
+  if (allowedNodes.has(coinHost)) {
+    event.returnValue = 1;
+    return;
+  }
+
+  const dialogOptions = {
+    type: 'warning',
+    buttons: [data.confirmationCancel, data.confirmationOk],
+    defaultId: 0,
+    title: data.confirmationTitle,
+    message: data.confirmationText,
+    cancelId: 0,
+    noLink: true,
+  }
+
+  dialog.showMessageBox(win, dialogOptions, response => {
+    if (response === 1) {
+      temporarilyAllowedCoin = {};
+      temporarilyAllowedCoin['id'] = data.id;
+      temporarilyAllowedCoin['url'] = data.url;
+      temporarilyAllowedCoin['host'] = coinHost;
+    
+      event.returnValue = 0;
+    } else {
+      event.returnValue = 2;
+    }
+  })
+});
+
+// Removes a coin temporarily added to the URL whitelist.
+ipcMain.on('removeTemporarilyAllowedCoinSync', (event) => {
+  temporarilyAllowedCoin = null;
+  event.returnValue = null;
+});
+
+// Adds a temporarily allowed coin to customNodeUrlsFile, so its URL can be accesses in future sessions.
+ipcMain.on('acceptTemporarilyAllowedCoinSync', (event) => {
+  coinsWithAllowedNodes.set(temporarilyAllowedCoin['id'] + '', temporarilyAllowedCoin['url']);
+  allowedNodes.set(temporarilyAllowedCoin['host'], true);
+
+  temporarilyAllowedCoin = null;
+  saveNodeUrls();
+
+  event.returnValue = null;
+});
+
+// Updates customNodeUrlsFile.
+function saveNodeUrls() {
+  const data = {};
+  coinsWithAllowedNodes.forEach((val, key) => {
+    data[key] = val;
+  });
+
+  fs.writeFileSync(customNodeUrlsFile, JSON.stringify(data), 'utf8');
+}
 
 // Enforce single instance
 const alreadyRunning = app.makeSingleInstance((commandLine, workingDirectory) => {

--- a/src/app/components/pages/settings/nodes/change-url/change-node-url.component.html
+++ b/src/app/components/pages/settings/nodes/change-url/change-node-url.component.html
@@ -2,7 +2,7 @@
   <div [formGroup]="form" *ngIf="showingUrlForm">
     <div class="form-field">
       <label for="url">{{ 'nodes.change.url-label' | translate}}</label>
-      <input formControlName="url" id="url" (keydown.enter)="change()">
+      <input formControlName="url" id="url" (keydown.enter)="startChange()">
     </div>
   </div>
   <div class="property-container" *ngIf="!showingUrlForm">

--- a/src/app/services/coin.service.spec.ts
+++ b/src/app/services/coin.service.spec.ts
@@ -1,11 +1,16 @@
 import { TestBed, inject } from '@angular/core/testing';
+import { TranslateService } from '@ngx-translate/core';
 
 import { CoinService } from './coin.service';
+import { MockTranslateService } from '../utils/test-mocks';
 
 describe('CoinService', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
-      providers: [CoinService]
+      providers: [
+        CoinService,
+        { provide: TranslateService, useClass: MockTranslateService },
+      ]
     });
   });
 

--- a/src/app/utils/test-mocks.ts
+++ b/src/app/utils/test-mocks.ts
@@ -86,6 +86,8 @@ export class MockCoinService {
     iconName: 'icon.png',
     bigIconName: 'big-icon.png',
   });
+
+  removeTemporarilyAllowedCoin() {}
 }
 
 export class MockWalletService {

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -314,6 +314,8 @@
 
     "change" : {
       "url-label": "Node URL (leave empty to use the default URL)",
+      "url-error": "The entered host is already in use for this or another coin.",
+      "cancelled-error": "Operation cancelled.",
       "cancel-button": "Cancel",
       "change-button": "Change",
       "return-button": "Return",
@@ -325,7 +327,14 @@
       "coin-name": "Coin",
       "node-version": "Node version",
       "last-block": "Last block",
-      "hours-burn-rate": "Hours burn rate"
+      "hours-burn-rate": "Hours burn rate",
+
+      "confirmation" : {
+        "title": "Security",
+        "text": "Do you really want to allow access to \"{{ url }}\"?",
+        "ok": "Ok",
+        "cancel": "Cancel"
+      }
     }
   },
 

--- a/src/assets/i18n/es.json
+++ b/src/assets/i18n/es.json
@@ -314,6 +314,8 @@
 
     "change" : {
       "url-label": "URL del nodo (dejar vacío para usar la URL por defecto)",
+      "url-error": "El host indicado ya está en uso por esta u otra moneda.",
+      "cancelled-error": "Operación cancelada.",
       "cancel-button": "Cancelar",
       "change-button": "Cambiar",
       "return-button": "Regresar",
@@ -325,7 +327,14 @@
       "coin-name": "Moneda",
       "node-version": "Versión del nodo",
       "last-block": "Último bloque",
-      "hours-burn-rate": "Tasa de quema de horas"
+      "hours-burn-rate": "Tasa de quema de horas",
+
+      "confirmation" : {
+        "title": "Seguridad",
+        "text": "¿Realmente desea permitir el acceso a \"{{ url }}\"?",
+        "ok": "Ok",
+        "cancel": "Cancelar"
+      }
     }
   },
 

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -1,5 +1,5 @@
 export const environment = {
   production: false,
   e2eTest: false,
-  enableCustomNodes: false,
+  enableCustomNodes: true,
 };


### PR DESCRIPTION
Changes:
- Now if the user tries to change the URL used to access the node of a coin, while using the Electron version, the user must accept the operation via a modal window. This way Electron can block access to all unknown hosts and only add exceptions when the user confirms them.

- The way in which the version that runs from the local file system works was not affected.

- The `connect-src` part of the  CSP of the the server used by the Electron version was changed from `'self' https://api.coinpaprika.com https://node.skycoin.net` to simply `*`. This is because the Electron code already blocks all connections to unknown hosts and the previous CSP would not allow the Electron code to add exeptions for custom nodes. In fact, the option to modify the URL stopped working after the CSP was added.

- Now the option for setting custom URLs is active in the test build.