### PR TITLE
Fix electron wallet cannot open explorer in browser

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+node_modules
+electron
+e2e
+dist

--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,5 @@ debug.log
 # System Files
 .DS_Store
 Thumbs.db
+
+/dist

--- a/electron/src/electron-main.js
+++ b/electron/src/electron-main.js
@@ -176,6 +176,12 @@ function createWindow() {
     });
   }
 
+  // Open links with target='_blank' in default browser.
+  win.webContents.on('new-window', function(e, url) {
+    e.preventDefault();
+    require('electron').shell.openExternal(url);
+  });
+
   // create application's main menu
   var template = [{
     label: 'Skycoin',
@@ -296,7 +302,7 @@ ipcMain.on('temporarilyAllowCoinSync', (event, data) => {
       temporarilyAllowedCoin['id'] = data.id;
       temporarilyAllowedCoin['url'] = data.url;
       temporarilyAllowedCoin['host'] = coinHost;
-    
+
       event.returnValue = 0;
     } else {
       event.returnValue = 2;


### PR DESCRIPTION
The electron wallet will open a terminal when clicking the `Skycoin
Explorer`.

Changes:
- Run `sehll.openExternal()` like we did in skycoin electron wallet to
open the url in default browser when `target = '_blank'`.
- Add `.dockerignore` to reduce the context size we send to docker daemon for building the docker
image.