### PR TITLE
Use a custom Snackbar

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -5,3 +5,4 @@
   </div>
 </div>
 <router-outlet></router-outlet>
+<app-msg-bar #msgBar></app-msg-bar>

--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -6,11 +6,12 @@ import { Observable } from 'rxjs/Observable';
 import { BehaviorSubject } from 'rxjs/BehaviorSubject';
 
 import { AppComponent } from './app.component';
-import { MockLanguageService, MockTranslatePipe, MockTranslateService, MockCustomMatDialogService } from './utils/test-mocks';
+import { MockLanguageService, MockTranslatePipe, MockTranslateService, MockCustomMatDialogService, MockMsgBarService } from './utils/test-mocks';
 import { LanguageService } from './services/language.service';
 import { CipherProvider } from './services/cipher.provider';
 import { CustomMatDialogService } from './services/custom-mat-dialog.service';
 import { Bip39WordListService } from './services/bip39-word-list.service';
+import { MsgBarService } from './services/msg-bar.service';
 
 describe('AppComponent', () => {
   let component: AppComponent;
@@ -27,7 +28,8 @@ describe('AppComponent', () => {
         { provide: CipherProvider, useValue: { browserHasCryptoInsideWorkers: new BehaviorSubject<boolean>(true) } },
         { provide: Renderer2, useValue: { addClass: null, removeClass: null } },
         { provide: CustomMatDialogService, useClass: MockCustomMatDialogService },
-        { provide: Bip39WordListService, useValue: {} }
+        { provide: Bip39WordListService, useValue: {} },
+        { provide: MsgBarService, useClass: MockMsgBarService },
       ]
     }).compileComponents();
   }));

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, Renderer2 } from '@angular/core';
+import { Component, OnInit, Renderer2, ViewChild } from '@angular/core';
 import { LanguageService } from './services/language.service';
 import { Router, RouterEvent, NavigationEnd } from '@angular/router';
 import { TranslateService } from '@ngx-translate/core';
@@ -8,6 +8,8 @@ import { environment } from '../environments/environment';
 import { CipherProvider } from './services/cipher.provider';
 import { CustomMatDialogService } from './services/custom-mat-dialog.service';
 import { Bip39WordListService } from './services/bip39-word-list.service';
+import { MsgBarComponent } from './components/layout/msg-bar/msg-bar.component';
+import { MsgBarService } from './services/msg-bar.service';
 
 @Component({
   selector: 'app-root',
@@ -15,6 +17,8 @@ import { Bip39WordListService } from './services/bip39-word-list.service';
   styleUrls: ['./app.component.scss'],
 })
 export class AppComponent implements OnInit {
+  @ViewChild('msgBar') msgBar: MsgBarComponent;
+
   current: number;
   highest: number;
   otcEnabled: boolean;
@@ -28,6 +32,7 @@ export class AppComponent implements OnInit {
     dialog: CustomMatDialogService,
     renderer: Renderer2,
     private bip38WordList: Bip39WordListService,
+    private msgBarService: MsgBarService,
   ) {
     router.events.subscribe((event: RouterEvent) => {
       if (event instanceof NavigationEnd) {
@@ -58,6 +63,8 @@ export class AppComponent implements OnInit {
         e.returnValue = '';
       }
     };
+
+    this.msgBarService.msgBarComponent = this.msgBar;
   }
 
   loading() {

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -14,7 +14,6 @@ import { MatMenuModule } from '@angular/material/menu';
 import { MatProgressBarModule } from '@angular/material/progress-bar';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { MatSelectModule } from '@angular/material/select';
-import { MatSnackBarModule } from '@angular/material/snack-bar';
 import { MatTabsModule } from '@angular/material/tabs';
 import { MatToolbarModule } from '@angular/material/toolbar';
 import { MatTooltipModule } from '@angular/material/tooltip';
@@ -85,6 +84,8 @@ import { CustomMatDialogService } from './services/custom-mat-dialog.service';
 import { Bip39WordListService } from './services/bip39-word-list.service';
 import { SendFormAdvancedComponent } from './components/pages/send-skycoin/send-form-advanced/send-form-advanced.component';
 import { SelectAddressComponent } from './components/pages/send-skycoin/send-form-advanced/select-address/select-address';
+import { MsgBarService } from './services/msg-bar.service';
+import { MsgBarComponent } from './components/layout/msg-bar/msg-bar.component';
 
 @NgModule({
   declarations: [
@@ -130,7 +131,8 @@ import { SelectAddressComponent } from './components/pages/send-skycoin/send-for
     ChangeNodeURLComponent,
     WalletOptionsComponent,
     SendFormAdvancedComponent,
-    SelectAddressComponent
+    SelectAddressComponent,
+    MsgBarComponent,
   ],
   entryComponents: [
     AddDepositAddressComponent,
@@ -162,7 +164,6 @@ import { SelectAddressComponent } from './components/pages/send-skycoin/send-for
     MatProgressBarModule,
     MatProgressSpinnerModule,
     MatSelectModule,
-    MatSnackBarModule,
     MatTabsModule,
     MatToolbarModule,
     MatTooltipModule,
@@ -196,7 +197,8 @@ import { SelectAddressComponent } from './components/pages/send-skycoin/send-for
     SpendingService,
     GlobalsService,
     CustomMatDialogService,
-    Bip39WordListService
+    Bip39WordListService,
+    MsgBarService,
   ],
   bootstrap: [AppComponent],
 })

--- a/src/app/components/layout/msg-bar/msg-bar.component.html
+++ b/src/app/components/layout/msg-bar/msg-bar.component.html
@@ -1,0 +1,10 @@
+<div class="main-container" [ngClass]="{ 'fix-small-screen-position': !UiIsShowingModalWindow }" *ngIf="visible">
+  <div [class]="'internal-container ' + (config.color ? config.color : 'red-background')">
+    <div class="icon-container" *ngIf="config.icon"><mat-icon>{{ config.icon }}</mat-icon></div>
+    <div class="text-container">
+      <div class="title" *ngIf="config.title">{{ config.title | translate }}</div>
+      <div class="text">{{ config.text | translate }}</div>
+    </div>
+    <div class="close-container"><mat-icon (click)="hide()">close</mat-icon></div>
+  </div>
+</div>

--- a/src/app/components/layout/msg-bar/msg-bar.component.scss
+++ b/src/app/components/layout/msg-bar/msg-bar.component.scss
@@ -1,0 +1,65 @@
+@import '../../../../theme/_variables';
+
+.main-container {
+  position: fixed;
+  bottom: 0px;
+  width: 100%;
+  z-index: 1000000;
+  display: flex;
+  flex-direction: row;
+  justify-content: center;
+}
+
+.internal-container {
+  color: white;
+  width: fit-content;
+  min-width: 40%;
+  max-width: 90%;
+  display: flex;
+  padding: 10px;
+  border-top-left-radius: 5px;
+  border-top-right-radius: 5px;
+}
+
+.red-background {
+  background-color: rgba(255, 0, 0, 0.7);
+}
+
+.green-background {
+  background-color: rgba(31, 177, 31, 0.7);
+}
+
+.yellow-background {
+  background-color: rgba(255, 94, 0, 0.7);
+}
+
+.icon-container {
+  margin-right: 10px;
+}
+
+.text-container {
+  flex-grow: 1;
+  margin-right: 10px;
+
+  .title {
+    font-size: 15px;
+    margin-top: -1px;
+  }
+
+  .text {
+    font-size: 13px;
+    margin-top: 2px;
+  }
+}
+
+.close-container {
+  mat-icon {
+    cursor: pointer;
+  }
+}
+
+@media (max-width: $max-small-width) {
+  .fix-small-screen-position {
+    margin-bottom: $mobile-nav-bar-height !important;
+  }
+}

--- a/src/app/components/layout/msg-bar/msg-bar.component.ts
+++ b/src/app/components/layout/msg-bar/msg-bar.component.ts
@@ -1,0 +1,53 @@
+import { Component, OnInit } from '@angular/core';
+import { CustomMatDialogService } from '../../../services/custom-mat-dialog.service';
+
+export enum MsgBarIcons {
+  Error = 'error',
+  Done = 'done',
+  Warning = 'warning',
+}
+
+export enum MsgBarColors {
+  Red = 'red-background',
+  Green = 'green-background',
+  Yellow = 'yellow-background',
+}
+
+export class MsgBarConfig {
+  title?: string;
+  text: string;
+  icon?: MsgBarIcons;
+  color?: MsgBarColors;
+}
+
+@Component({
+  selector: 'app-msg-bar',
+  templateUrl: './msg-bar.component.html',
+  styleUrls: ['./msg-bar.component.scss'],
+})
+export class MsgBarComponent implements OnInit {
+  config = new MsgBarConfig();
+  visible = false;
+  UiIsShowingModalWindow = false;
+
+  constructor(private dialog: CustomMatDialogService) { }
+
+  ngOnInit() {
+    this.dialog.showingDialog.subscribe(value => {
+      this.UiIsShowingModalWindow = value;
+    });
+  }
+
+  show() {
+    if (this.visible) {
+      this.visible = false;
+      setTimeout(() => this.visible = true, 32);
+    } else {
+      this.visible = true;
+    }
+  }
+
+  hide() {
+    this.visible = false;
+  }
+}

--- a/src/app/components/layout/select-coin-overlay/select-coin-overlay.component.spec.ts
+++ b/src/app/components/layout/select-coin-overlay/select-coin-overlay.component.spec.ts
@@ -1,13 +1,14 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
-import { MatIconModule, MatDialogRef, MatSnackBar } from '@angular/material';
+import { MatIconModule, MatDialogRef } from '@angular/material';
 import { NO_ERRORS_SCHEMA } from '@angular/core';
 import { TranslateService } from '@ngx-translate/core';
 
 import { SelectCoinOverlayComponent } from './select-coin-overlay.component';
-import { MockTranslatePipe, MockMatDialogRef, MockCoinService, MockWalletService, MockSpendingService, MockTranslateService, MockMatSnackBar } from '../../../utils/test-mocks';
+import { MockTranslatePipe, MockMatDialogRef, MockCoinService, MockWalletService, MockSpendingService, MockTranslateService, MockMsgBarService } from '../../../utils/test-mocks';
 import { CoinService } from '../../../services/coin.service';
 import { WalletService } from '../../../services/wallet/wallet.service';
 import { SpendingService } from '../../../services/wallet/spending.service';
+import { MsgBarService } from '../../../services/msg-bar.service';
 
 describe('SelectCoinOverlayComponent', () => {
   let component: SelectCoinOverlayComponent;
@@ -26,7 +27,7 @@ describe('SelectCoinOverlayComponent', () => {
         { provide: WalletService, useClass: MockWalletService },
         { provide: SpendingService, useClass: MockSpendingService },
         { provide: TranslateService, useClass: MockTranslateService },
-        { provide: MatSnackBar, useClass: MockMatSnackBar }
+        { provide: MsgBarService, useClass: MockMsgBarService },
       ]
     })
     .compileComponents();

--- a/src/app/components/layout/select-coin-overlay/select-coin-overlay.component.ts
+++ b/src/app/components/layout/select-coin-overlay/select-coin-overlay.component.ts
@@ -1,6 +1,5 @@
 import { Component, Input, HostListener, ViewChild, ElementRef, OnInit, OnDestroy } from '@angular/core';
 import { MatDialogRef } from '@angular/material/dialog';
-import { MatSnackBar, MatSnackBarConfig } from '@angular/material';
 import { Observable } from 'rxjs/Observable';
 import 'rxjs/add/observable/fromEvent';
 import 'rxjs/add/operator/debounceTime';
@@ -11,6 +10,7 @@ import { BaseCoin } from '../../../coins/basecoin';
 import { ISubscription } from 'rxjs/Subscription';
 import { WalletService } from '../../../services/wallet/wallet.service';
 import { SpendingService } from '../../../services/wallet/spending.service';
+import { MsgBarService } from '../../../services/msg-bar.service';
 
 @Component({
   selector: 'app-select-coin-overlay',
@@ -31,7 +31,7 @@ export class SelectCoinOverlayComponent implements OnInit, OnDestroy {
     private walletService: WalletService,
     private spendingService: SpendingService,
     private translate: TranslateService,
-    private snackbar: MatSnackBar
+    private msgBarService: MsgBarService,
   ) { }
 
   ngOnInit() {
@@ -91,7 +91,7 @@ export class SelectCoinOverlayComponent implements OnInit, OnDestroy {
 
   ngOnDestroy() {
     this.searchSuscription.unsubscribe();
-    this.snackbar.dismiss();
+    this.msgBarService.hide();
   }
 
   @HostListener('document:keydown', ['$event'])
@@ -102,11 +102,9 @@ export class SelectCoinOverlayComponent implements OnInit, OnDestroy {
   }
 
   close(result: BaseCoin | null) {
-    this.snackbar.dismiss();
+    this.msgBarService.hide();
     if (result && this.spendingService.isInjectingTx) {
-      const config = new MatSnackBarConfig();
-      config.duration = 10000;
-      this.snackbar.open(this.translate.instant('change-coin.injecting-tx'), null, config);
+      this.msgBarService.showError('change-coin.injecting-tx');
       return;
     }
     this.dialogRef.close(result);

--- a/src/app/components/pages/onboarding/onboarding-create-wallet/onboarding-create-wallet.component.spec.ts
+++ b/src/app/components/pages/onboarding/onboarding-create-wallet/onboarding-create-wallet.component.spec.ts
@@ -1,6 +1,5 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { NO_ERRORS_SCHEMA } from '@angular/core';
-import { MatSnackBarModule } from '@angular/material';
 import { RouterTestingModule } from '@angular/router/testing';
 import { FormBuilder } from '@angular/forms';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
@@ -9,12 +8,13 @@ import { TranslateService } from '@ngx-translate/core';
 import { OnboardingCreateWalletComponent } from './onboarding-create-wallet.component';
 import { WalletService } from '../../../../services/wallet/wallet.service';
 import { CoinService } from '../../../../services/coin.service';
-import { MockTranslatePipe, MockWalletService, MockCoinService, MockLanguageService, MockBlockchainService, MockCustomMatDialogService } from '../../../../utils/test-mocks';
+import { MockTranslatePipe, MockWalletService, MockCoinService, MockLanguageService, MockBlockchainService, MockCustomMatDialogService, MockMsgBarService } from '../../../../utils/test-mocks';
 import { LanguageService } from '../../../../services/language.service';
 import { CreateWalletFormComponent } from '../../wallets/create-wallet/create-wallet-form/create-wallet-form.component';
 import { BlockchainService } from '../../../../services/blockchain.service';
 import { CustomMatDialogService } from '../../../../services/custom-mat-dialog.service';
 import { Bip39WordListService } from '../../../../services/bip39-word-list.service';
+import { MsgBarService } from '../../../../services/msg-bar.service';
 
 describe('OnboardingCreateWalletComponent', () => {
   let component: OnboardingCreateWalletComponent;
@@ -30,7 +30,6 @@ describe('OnboardingCreateWalletComponent', () => {
       imports: [
         RouterTestingModule,
         BrowserAnimationsModule,
-        MatSnackBarModule
       ],
       providers: [
         FormBuilder,
@@ -44,6 +43,7 @@ describe('OnboardingCreateWalletComponent', () => {
           useValue: jasmine.createSpyObj('TranslateService', ['instant'])
         },
         { provide: Bip39WordListService, useValue: { validateWord: true } },
+        { provide: MsgBarService, useClass: MockMsgBarService },
       ],
       schemas: [ NO_ERRORS_SCHEMA ]
     });

--- a/src/app/components/pages/onboarding/onboarding-create-wallet/onboarding-create-wallet.component.ts
+++ b/src/app/components/pages/onboarding/onboarding-create-wallet/onboarding-create-wallet.component.ts
@@ -1,6 +1,5 @@
 import { Component, OnInit, ViewChild, OnDestroy } from '@angular/core';
 import { Router } from '@angular/router';
-import { MatSnackBarConfig, MatSnackBar } from '@angular/material';
 import { TranslateService } from '@ngx-translate/core';
 import { ISubscription } from 'rxjs/Subscription';
 import { Observable } from 'rxjs/Observable';
@@ -16,6 +15,7 @@ import { ConfirmationData, Wallet } from '../../../../app.datatypes';
 import { BlockchainService } from '../../../../services/blockchain.service';
 import { CustomMatDialogService } from '../../../../services/custom-mat-dialog.service';
 import { config } from '../../../../app.config';
+import { MsgBarService } from '../../../../services/msg-bar.service';
 
 @Component({
   selector: 'app-onboarding-create-wallet',
@@ -40,11 +40,11 @@ export class OnboardingCreateWalletComponent implements OnInit, OnDestroy {
     private dialog: CustomMatDialogService,
     private walletService: WalletService,
     private router: Router,
-    private snackBar: MatSnackBar,
     private coinService: CoinService,
     private languageService: LanguageService,
     private blockchainService: BlockchainService,
     private translate: TranslateService,
+    private msgBarService: MsgBarService,
   ) { }
 
   ngOnInit() {
@@ -57,7 +57,7 @@ export class OnboardingCreateWalletComponent implements OnInit, OnDestroy {
 
   ngOnDestroy() {
     this.removeSlowInfoSubscription();
-    this.snackBar.dismiss();
+    this.msgBarService.hide();
     this.subscription.unsubscribe();
   }
 
@@ -189,11 +189,9 @@ export class OnboardingCreateWalletComponent implements OnInit, OnDestroy {
   private onCreateError(errorMesasge: string) {
     this.showSlowMobileInfo = false;
     this.removeSlowInfoSubscription();
-    const snackBarConfig = new MatSnackBarConfig();
-    snackBarConfig.duration = 5000;
-    this.snackBar.open(errorMesasge, null, snackBarConfig);
+    this.msgBarService.showError(errorMesasge);
 
-    this.createButton.setError(errorMesasge);
+    this.createButton.resetState();
     this.creatingWallet = false;
   }
 

--- a/src/app/components/pages/send-skycoin/send-form-advanced/send-form-advanced.component.spec.ts
+++ b/src/app/components/pages/send-skycoin/send-form-advanced/send-form-advanced.component.spec.ts
@@ -1,6 +1,5 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { NO_ERRORS_SCHEMA } from '@angular/core';
-import { MatSnackBarModule } from '@angular/material';
 import { FormBuilder } from '@angular/forms';
 
 import { SendFormAdvancedComponent } from './send-form-advanced.component';
@@ -18,7 +17,9 @@ import { MockTranslatePipe,
   MockBlockchainService,
   MockCustomMatDialogService,
   MockNavBarService,
-  MockPriceService } from '../../../../utils/test-mocks';
+  MockPriceService,
+  MockMsgBarService} from '../../../../utils/test-mocks';
+import { MsgBarService } from '../../../../services/msg-bar.service';
 
 describe('SendFormAdvancedComponent', () => {
   let component: SendFormAdvancedComponent;
@@ -28,7 +29,6 @@ describe('SendFormAdvancedComponent', () => {
     TestBed.configureTestingModule({
       declarations: [ SendFormAdvancedComponent, MockTranslatePipe ],
       schemas: [ NO_ERRORS_SCHEMA ],
-      imports: [ MatSnackBarModule ],
       providers: [
         FormBuilder,
         { provide: WalletService, useClass: MockWalletService },
@@ -38,6 +38,7 @@ describe('SendFormAdvancedComponent', () => {
         { provide: CustomMatDialogService, useClass: MockCustomMatDialogService },
         { provide: NavBarService, useClass: MockNavBarService },
         { provide: PriceService, useClass: MockPriceService },
+        { provide: MsgBarService, useClass: MockMsgBarService },
       ]
     })
     .compileComponents();

--- a/src/app/components/pages/send-skycoin/send-form-advanced/send-form-advanced.component.ts
+++ b/src/app/components/pages/send-skycoin/send-form-advanced/send-form-advanced.component.ts
@@ -1,6 +1,6 @@
 import { Component, EventEmitter, Input, OnDestroy, OnInit, Output, ViewChild } from '@angular/core';
 import { FormArray, FormBuilder, FormGroup, Validators } from '@angular/forms';
-import { MatSnackBar, MatDialogConfig, MatSnackBarConfig } from '@angular/material';
+import { MatDialogConfig } from '@angular/material';
 import { ISubscription } from 'rxjs/Subscription';
 import { BigNumber } from 'bignumber.js';
 import { Observable } from 'rxjs/Observable';
@@ -22,6 +22,7 @@ import { CoinService } from '../../../../services/coin.service';
 import { DoubleButtonActive } from '../../../layout/double-button/double-button.component';
 import { PriceService } from '../../../../services/price.service';
 import { SendFormComponent } from '../send-form/send-form.component';
+import { MsgBarService } from '../../../../services/msg-bar.service';
 
 @Component({
   selector: 'app-send-form-advanced',
@@ -62,11 +63,11 @@ export class SendFormAdvancedComponent implements OnInit, OnDestroy {
     private spendingService: SpendingService,
     private formBuilder: FormBuilder,
     private dialog: CustomMatDialogService,
-    private snackbar: MatSnackBar,
     private navbarService: NavBarService,
     private blockchainService: BlockchainService,
     private coinService: CoinService,
     private priceService: PriceService,
+    private msgBarService: MsgBarService,
   ) { }
 
   ngOnInit() {
@@ -144,7 +145,7 @@ export class SendFormAdvancedComponent implements OnInit, OnDestroy {
     this.closeGetOutputsSubscriptions();
     this.subscriptionsGroup.forEach(sub => sub.unsubscribe());
     this.navbarService.hideSwitch();
-    this.snackbar.dismiss();
+    this.msgBarService.hide();
     this.destinationSubscriptions.forEach(s => s.unsubscribe());
   }
 
@@ -210,7 +211,7 @@ export class SendFormAdvancedComponent implements OnInit, OnDestroy {
       return;
     }
 
-    this.snackbar.dismiss();
+    this.msgBarService.hide();
     this.button.resetState();
 
     const wallet = this.form.value.wallet;
@@ -489,10 +490,8 @@ export class SendFormAdvancedComponent implements OnInit, OnDestroy {
         }, 3000);
       })
       .catch(error => {
-        const snackBarConfig = new MatSnackBarConfig();
-        snackBarConfig.duration = 300000;
-        this.snackbar.open(error.message, null, snackBarConfig);
-        this.button.setError(error.message);
+        this.msgBarService.showError(error.message);
+        this.button.resetState();
       });
   }
 

--- a/src/app/components/pages/send-skycoin/send-form/send-form.component.spec.ts
+++ b/src/app/components/pages/send-skycoin/send-form/send-form.component.spec.ts
@@ -1,5 +1,4 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
-import { MatSnackBarModule } from '@angular/material';
 import { NO_ERRORS_SCHEMA } from '@angular/core';
 import { FormBuilder } from '@angular/forms';
 
@@ -18,7 +17,9 @@ import { MockTranslatePipe,
   MockBlockchainService,
   MockCustomMatDialogService,
   MockNavBarService,
-  MockPriceService } from '../../../../utils/test-mocks';
+  MockPriceService,
+  MockMsgBarService} from '../../../../utils/test-mocks';
+import { MsgBarService } from '../../../../services/msg-bar.service';
 
 describe('SendFormComponent', () => {
   let component: SendFormComponent;
@@ -28,7 +29,6 @@ describe('SendFormComponent', () => {
     TestBed.configureTestingModule({
       declarations: [ SendFormComponent, MockTranslatePipe ],
       schemas: [ NO_ERRORS_SCHEMA ],
-      imports: [ MatSnackBarModule ],
       providers: [
         FormBuilder,
         { provide: WalletService, useClass: MockWalletService },
@@ -38,6 +38,7 @@ describe('SendFormComponent', () => {
         { provide: CustomMatDialogService, useClass: MockCustomMatDialogService },
         { provide: NavBarService, useClass: MockNavBarService },
         { provide: PriceService, useClass: MockPriceService },
+        { provide: MsgBarService, useClass: MockMsgBarService },
       ]
     }).compileComponents();
   }));

--- a/src/app/components/pages/send-skycoin/send-form/send-form.component.ts
+++ b/src/app/components/pages/send-skycoin/send-form/send-form.component.ts
@@ -1,6 +1,5 @@
 import { Component, EventEmitter, Input, OnDestroy, OnInit, Output, ViewChild } from '@angular/core';
 import { FormBuilder, FormControl, FormGroup, Validators } from '@angular/forms';
-import { MatSnackBar, MatSnackBarConfig } from '@angular/material';
 import { ISubscription } from 'rxjs/Subscription';
 import 'rxjs/add/operator/delay';
 import 'rxjs/add/operator/filter';
@@ -20,6 +19,7 @@ import { config } from '../../../../app.config';
 import { NavBarService } from '../../../../services/nav-bar.service';
 import { DoubleButtonActive } from '../../../layout/double-button/double-button.component';
 import { PriceService } from '../../../../services/price.service';
+import { MsgBarService } from '../../../../services/msg-bar.service';
 
 @Component({
   selector: 'app-send-form',
@@ -53,10 +53,10 @@ export class SendFormComponent implements OnInit, OnDestroy {
     private formBuilder: FormBuilder,
     private walletService: WalletService,
     private spendingService: SpendingService,
-    private snackbar: MatSnackBar,
     private dialog: CustomMatDialogService,
     private coinService: CoinService,
     private navbarService: NavBarService,
+    private msgBarService: MsgBarService,
     priceService: PriceService,
   ) {
     this.subscriptionsGroup.push(priceService.price.subscribe(price => {
@@ -97,7 +97,7 @@ export class SendFormComponent implements OnInit, OnDestroy {
     this.removeProcessSubscription();
     this.subscriptionsGroup.forEach(sub => sub.unsubscribe());
     this.navbarService.hideSwitch();
-    this.snackbar.dismiss();
+    this.msgBarService.hide();
   }
 
   onVerify(event = null) {
@@ -109,7 +109,7 @@ export class SendFormComponent implements OnInit, OnDestroy {
       return;
     }
 
-    this.snackbar.dismiss();
+    this.msgBarService.hide();
     this.button.resetState();
 
     const wallet = this.form.value.wallet;
@@ -236,10 +236,8 @@ export class SendFormComponent implements OnInit, OnDestroy {
   private onError(error) {
     this.showSlowMobileInfo = false;
     this.removeSlowInfoSubscription();
-    const snackBarConfig = new MatSnackBarConfig();
-    snackBarConfig.duration = 300000;
-    this.snackbar.open(error.message, null, snackBarConfig);
-    this.button.setError(error.message);
+    this.msgBarService.showError(error.message);
+    this.button.resetState();
   }
 
   private initForm() {

--- a/src/app/components/pages/send-skycoin/send-verify/send-verify.component.spec.ts
+++ b/src/app/components/pages/send-skycoin/send-verify/send-verify.component.spec.ts
@@ -1,11 +1,11 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
-import { MatSnackBar } from '@angular/material';
 import { NO_ERRORS_SCHEMA } from '@angular/core';
 
 import { SendVerifyComponent } from './send-verify.component';
 import { BalanceService } from '../../../../services/wallet/balance.service';
 import { SpendingService } from '../../../../services/wallet/spending.service';
-import { MockTranslatePipe, MockBalanceService, MockSpendingService, MockMatSnackBar } from '../../../../utils/test-mocks';
+import { MockTranslatePipe, MockBalanceService, MockSpendingService, MockMsgBarService } from '../../../../utils/test-mocks';
+import { MsgBarService } from '../../../../services/msg-bar.service';
 
 describe('SendVerifyComponent', () => {
   let component: SendVerifyComponent;
@@ -18,7 +18,7 @@ describe('SendVerifyComponent', () => {
       providers: [
         { provide: BalanceService, useClass: MockBalanceService },
         { provide: SpendingService, useClass: MockSpendingService },
-        { provide: MatSnackBar, useClass: MockMatSnackBar }
+        { provide: MsgBarService, useClass: MockMsgBarService },
       ]
     })
     .compileComponents();

--- a/src/app/components/pages/send-skycoin/send-verify/send-verify.component.ts
+++ b/src/app/components/pages/send-skycoin/send-verify/send-verify.component.ts
@@ -1,11 +1,11 @@
 import { Component, EventEmitter, Input, OnDestroy, Output, ViewChild } from '@angular/core';
-import { MatSnackBar, MatSnackBarConfig } from '@angular/material';
 
 import { PreviewTransaction } from '../../../../app.datatypes';
 import { BalanceService } from '../../../../services/wallet/balance.service';
 import { SpendingService } from '../../../../services/wallet/spending.service';
 import { ButtonComponent } from '../../../layout/button/button.component';
 import { parseResponseMessage } from './../../../../utils/errors';
+import { MsgBarService } from '../../../../services/msg-bar.service';
 
 @Component({
   selector: 'app-send-verify',
@@ -21,15 +21,15 @@ export class SendVerifyComponent implements OnDestroy {
   constructor(
     private balanceService: BalanceService,
     private spendingService: SpendingService,
-    private snackbar: MatSnackBar
+    private msgBarService: MsgBarService,
   ) {}
 
   ngOnDestroy() {
-    this.snackbar.dismiss();
+    this.msgBarService.hide();
   }
 
   send() {
-    this.snackbar.dismiss();
+    this.msgBarService.hide();
     this.sendButton.resetState();
     this.sendButton.setLoading();
     this.backButton.setDisabled();
@@ -46,19 +46,14 @@ export class SendVerifyComponent implements OnDestroy {
   }
 
   private onSuccess() {
-    this.sendButton.setSuccess();
-    this.sendButton.setDisabled();
-
+    setTimeout(() => this.msgBarService.showDone('send.sent'));
     this.balanceService.startGettingBalances();
-    setTimeout(() => this.onBack.emit(true), 3000);
+    this.onBack.emit(true);
   }
 
   private onError(error) {
     const errorMessage = error.message ? error.message : parseResponseMessage(error['_body']);
-    const config = new MatSnackBarConfig();
-    config.duration = 300000;
-    this.snackbar.open(errorMessage, null, config);
-    this.sendButton.setError(errorMessage);
-    this.backButton.setEnabled();
+    this.msgBarService.showError(errorMessage);
+    this.sendButton.resetState();
   }
 }

--- a/src/app/components/pages/settings/nodes/change-url/change-node-url.component.spec.ts
+++ b/src/app/components/pages/settings/nodes/change-url/change-node-url.component.spec.ts
@@ -1,13 +1,14 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { NO_ERRORS_SCHEMA } from '@angular/core';
-import { MAT_DIALOG_DATA, MatDialogRef, MatSnackBarModule } from '@angular/material';
+import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material';
 import { FormBuilder } from '@angular/forms';
 import { HttpClientModule } from '@angular/common/http';
 import { TranslateService } from '@ngx-translate/core';
 
 import { ChangeNodeURLComponent } from './change-node-url.component';
-import { MockTranslatePipe, MockCoinService } from '../../../../../utils/test-mocks';
+import { MockTranslatePipe, MockCoinService, MockMsgBarService } from '../../../../../utils/test-mocks';
 import { CoinService } from '../../../../../services/coin.service';
+import { MsgBarService } from '../../../../../services/msg-bar.service';
 
 describe('ChangeNodeURLComponent', () => {
   let component: ChangeNodeURLComponent;
@@ -16,7 +17,7 @@ describe('ChangeNodeURLComponent', () => {
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       declarations: [ ChangeNodeURLComponent, MockTranslatePipe ],
-      imports: [ HttpClientModule, MatSnackBarModule ],
+      imports: [ HttpClientModule ],
       schemas: [ NO_ERRORS_SCHEMA ],
       providers: [
         FormBuilder,
@@ -27,6 +28,7 @@ describe('ChangeNodeURLComponent', () => {
           provide: TranslateService,
           useValue: jasmine.createSpyObj('TranslateService', ['instant'])
         },
+        { provide: MsgBarService, useClass: MockMsgBarService },
       ]
     })
     .compileComponents();

--- a/src/app/components/pages/wallets/change-name/change-name.component.spec.ts
+++ b/src/app/components/pages/wallets/change-name/change-name.component.spec.ts
@@ -5,7 +5,8 @@ import { FormBuilder } from '@angular/forms';
 
 import { ChangeNameComponent } from './change-name.component';
 import { WalletService } from '../../../../services/wallet/wallet.service';
-import { MockTranslatePipe, MockWalletService } from '../../../../utils/test-mocks';
+import { MockTranslatePipe, MockWalletService, MockMsgBarService } from '../../../../utils/test-mocks';
+import { MsgBarService } from '../../../../services/msg-bar.service';
 
 describe('ChangeNameComponent', () => {
   let component: ChangeNameComponent;
@@ -19,7 +20,8 @@ describe('ChangeNameComponent', () => {
         FormBuilder,
         { provide: WalletService, useClass: MockWalletService },
         { provide: MatDialogRef, useValue: {} },
-        { provide: MAT_DIALOG_DATA, useValue: {} }
+        { provide: MAT_DIALOG_DATA, useValue: {} },
+        { provide: MsgBarService, useClass: MockMsgBarService },
       ]
     })
     .compileComponents();

--- a/src/app/components/pages/wallets/change-name/change-name.component.ts
+++ b/src/app/components/pages/wallets/change-name/change-name.component.ts
@@ -1,17 +1,18 @@
-import { Component, Inject, OnInit, ViewChild } from '@angular/core';
+import { Component, Inject, OnInit, ViewChild, OnDestroy } from '@angular/core';
 import { FormBuilder, FormGroup, Validators } from '@angular/forms';
 import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
 
 import { Wallet } from '../../../../app.datatypes';
 import { WalletService } from '../../../../services/wallet/wallet.service';
 import { ButtonComponent } from '../../../layout/button/button.component';
+import { MsgBarService } from '../../../../services/msg-bar.service';
 
 @Component({
   selector: 'app-change-name',
   templateUrl: './change-name.component.html',
   styleUrls: ['./change-name.component.scss'],
 })
-export class ChangeNameComponent implements OnInit {
+export class ChangeNameComponent implements OnInit, OnDestroy {
   @ViewChild('button') button: ButtonComponent;
   form: FormGroup;
 
@@ -20,10 +21,15 @@ export class ChangeNameComponent implements OnInit {
     public dialogRef: MatDialogRef<ChangeNameComponent>,
     private formBuilder: FormBuilder,
     private walletService: WalletService,
+    private msgBarService: MsgBarService,
   ) {}
 
   ngOnInit() {
     this.initForm();
+  }
+
+  ngOnDestroy() {
+    this.msgBarService.hide();
   }
 
   closePopup() {
@@ -39,6 +45,8 @@ export class ChangeNameComponent implements OnInit {
     this.data.label = this.form.value.label;
     this.walletService.saveWallets();
     this.dialogRef.close();
+
+    setTimeout(() => this.msgBarService.showDone('common.changes-made'));
   }
 
   private initForm() {

--- a/src/app/components/pages/wallets/create-wallet/create-wallet.component.spec.ts
+++ b/src/app/components/pages/wallets/create-wallet/create-wallet.component.spec.ts
@@ -1,14 +1,15 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { NO_ERRORS_SCHEMA } from '@angular/core';
-import { MAT_DIALOG_DATA, MatDialogRef, MatSnackBarModule } from '@angular/material';
+import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material';
 import { TranslateService } from '@ngx-translate/core';
 
 import { CreateWalletComponent } from './create-wallet.component';
 import { WalletService } from '../../../../services/wallet/wallet.service';
 import { CoinService } from '../../../../services/coin.service';
-import { MockTranslatePipe, MockWalletService, MockCoinService, MockBlockchainService, MockCustomMatDialogService } from '../../../../utils/test-mocks';
+import { MockTranslatePipe, MockWalletService, MockCoinService, MockBlockchainService, MockCustomMatDialogService, MockMsgBarService } from '../../../../utils/test-mocks';
 import { BlockchainService } from '../../../../services/blockchain.service';
 import { CustomMatDialogService } from '../../../../services/custom-mat-dialog.service';
+import { MsgBarService } from '../../../../services/msg-bar.service';
 
 describe('CreateWalletComponent', () => {
   let component: CreateWalletComponent;
@@ -17,7 +18,6 @@ describe('CreateWalletComponent', () => {
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       declarations: [ CreateWalletComponent, MockTranslatePipe ],
-      imports: [ MatSnackBarModule ],
       schemas: [ NO_ERRORS_SCHEMA ],
       providers: [
         { provide: MAT_DIALOG_DATA, useValue: {} },
@@ -30,6 +30,7 @@ describe('CreateWalletComponent', () => {
           provide: TranslateService,
           useValue: jasmine.createSpyObj('TranslateService', ['instant'])
         },
+        { provide: MsgBarService, useClass: MockMsgBarService },
       ]
     })
     .compileComponents();

--- a/src/app/components/pages/wallets/create-wallet/create-wallet.component.ts
+++ b/src/app/components/pages/wallets/create-wallet/create-wallet.component.ts
@@ -1,6 +1,6 @@
 import { Component, Inject, ViewChild, OnDestroy } from '@angular/core';
 import { MatDialogRef } from '@angular/material/dialog';
-import { MAT_DIALOG_DATA, MatSnackBarConfig, MatSnackBar } from '@angular/material';
+import { MAT_DIALOG_DATA } from '@angular/material';
 import { TranslateService } from '@ngx-translate/core';
 import { ISubscription } from 'rxjs/Subscription';
 import { Observable } from 'rxjs/Observable';
@@ -15,6 +15,7 @@ import { scanAddresses } from '../../../../utils';
 import { BlockchainService } from '../../../../services/blockchain.service';
 import { CustomMatDialogService } from '../../../../services/custom-mat-dialog.service';
 import { config } from '../../../../app.config';
+import { MsgBarService } from '../../../../services/msg-bar.service';
 
 @Component({
   selector: 'app-create-wallet',
@@ -34,16 +35,16 @@ export class CreateWalletComponent implements OnDestroy {
     @Inject(MAT_DIALOG_DATA) public data,
     public dialogRef: MatDialogRef<CreateWalletComponent>,
     private walletService: WalletService,
-    private snackBar: MatSnackBar,
     private coinService: CoinService,
     private blockchainService: BlockchainService,
     private translate: TranslateService,
-    private dialog: CustomMatDialogService
+    private dialog: CustomMatDialogService,
+    private msgBarService: MsgBarService,
   ) { }
 
   ngOnDestroy() {
     this.removeSlowInfoSubscription();
-    this.snackBar.dismiss();
+    this.msgBarService.hide();
   }
 
   closePopup() {
@@ -99,15 +100,14 @@ export class CreateWalletComponent implements OnDestroy {
     this.removeSlowInfoSubscription();
     this.createButton.setSuccess();
     this.dialogRef.close();
+    setTimeout(() => this.msgBarService.showDone('wallet.new.wallet-created'));
   }
 
   private onCreateError(errorMesasge: string) {
     this.showSlowMobileInfo = false;
     this.removeSlowInfoSubscription();
-    const snackBarConfig = new MatSnackBarConfig();
-    snackBarConfig.duration = 5000;
-    this.snackBar.open(errorMesasge, null, snackBarConfig);
-    this.createButton.setError(errorMesasge);
+    this.msgBarService.showError(errorMesasge);
+    this.createButton.resetState();
 
     this.disableDismiss = false;
   }

--- a/src/app/components/pages/wallets/scan-addresses/scan-addresses.component.spec.ts
+++ b/src/app/components/pages/wallets/scan-addresses/scan-addresses.component.spec.ts
@@ -1,6 +1,6 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { NO_ERRORS_SCHEMA } from '@angular/core';
-import { MAT_DIALOG_DATA, MatDialogRef, MatSnackBar } from '@angular/material';
+import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material';
 import { FormBuilder } from '@angular/forms';
 
 import { ScanAddressesComponent } from './scan-addresses.component';

--- a/src/app/components/pages/wallets/unlock-wallet/unlock-wallet.component.spec.ts
+++ b/src/app/components/pages/wallets/unlock-wallet/unlock-wallet.component.spec.ts
@@ -1,11 +1,12 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { NO_ERRORS_SCHEMA } from '@angular/core';
-import { MAT_DIALOG_DATA, MatDialogRef, MatSnackBar } from '@angular/material';
+import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material';
 import { FormBuilder } from '@angular/forms';
 
 import { UnlockWalletComponent } from './unlock-wallet.component';
 import { WalletService } from '../../../../services/wallet/wallet.service';
-import { MockTranslatePipe, MockWalletService, MockMatSnackBar } from '../../../../utils/test-mocks';
+import { MockTranslatePipe, MockWalletService, MockMsgBarService } from '../../../../utils/test-mocks';
+import { MsgBarService } from '../../../../services/msg-bar.service';
 
 describe('UnlockWalletComponent', () => {
   let component: UnlockWalletComponent;
@@ -20,7 +21,7 @@ describe('UnlockWalletComponent', () => {
         { provide: WalletService, useClass: MockWalletService },
         { provide: MatDialogRef, useValue: {} },
         { provide: MAT_DIALOG_DATA, useValue: {} },
-        { provide: MatSnackBar, useClass: MockMatSnackBar }
+        { provide: MsgBarService, useClass: MockMsgBarService },
       ]
     })
     .compileComponents();

--- a/src/app/components/pages/wallets/unlock-wallet/unlock-wallet.component.ts
+++ b/src/app/components/pages/wallets/unlock-wallet/unlock-wallet.component.ts
@@ -1,13 +1,13 @@
 import { Component, EventEmitter, Inject, OnInit, Output, ViewChild, OnDestroy } from '@angular/core';
 import { FormBuilder, FormGroup, Validators, FormControl } from '@angular/forms';
 import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
-import { MatSnackBar, MatSnackBarConfig } from '@angular/material/snack-bar';
 import { ISubscription } from 'rxjs/Subscription';
 import { Observable } from 'rxjs/Observable';
 
 import { Wallet } from '../../../../app.datatypes';
 import { WalletService } from '../../../../services/wallet/wallet.service';
 import { config } from '../../../../app.config';
+import { MsgBarService } from '../../../../services/msg-bar.service';
 
 export class ConfirmSeedParams {
   wallet: Wallet;
@@ -38,7 +38,7 @@ export class UnlockWalletComponent implements OnInit, OnDestroy {
     public dialogRef: MatDialogRef<UnlockWalletComponent>,
     private formBuilder: FormBuilder,
     private walletService: WalletService,
-    private snackbar: MatSnackBar
+    private msgBarService: MsgBarService,
   ) {
     if (data.wallet) {
       this.showConfirmSeedWarning = true;
@@ -54,7 +54,7 @@ export class UnlockWalletComponent implements OnInit, OnDestroy {
   }
 
   ngOnDestroy() {
-    this.snackbar.dismiss();
+    this.msgBarService.hide();
     this.removeProgressSubscriptions();
     this.removeSlowInfoSubscription();
   }
@@ -111,10 +111,8 @@ export class UnlockWalletComponent implements OnInit, OnDestroy {
     this.removeSlowInfoSubscription();
     this.removeProgressSubscriptions();
     this.disableDismiss = false;
-    const snackBarConfig = new MatSnackBarConfig();
-    snackBarConfig.duration = 5000;
-    this.snackbar.open(error.message, null, snackBarConfig);
-    this.unlockButton.setError(error.message);
+    this.msgBarService.showError(error.message);
+    this.unlockButton.resetState();
   }
 
   private removeProgressSubscriptions() {

--- a/src/app/components/pages/wallets/wallet-detail/wallet-detail.component.spec.ts
+++ b/src/app/components/pages/wallets/wallet-detail/wallet-detail.component.spec.ts
@@ -1,13 +1,14 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
-import { MatSnackBar, MatMenuModule } from '@angular/material';
+import { MatMenuModule } from '@angular/material';
 import { RouterTestingModule } from '@angular/router/testing';
 import { NO_ERRORS_SCHEMA } from '@angular/core';
 import { TranslateService } from '@ngx-translate/core';
 
 import { WalletDetailComponent } from './wallet-detail.component';
 import { WalletService } from '../../../../services/wallet/wallet.service';
-import { MockTranslatePipe, MockWalletService, MockTranslateService, MockMatSnackBar, MockCustomMatDialogService } from '../../../../utils/test-mocks';
+import { MockTranslatePipe, MockWalletService, MockTranslateService, MockCustomMatDialogService, MockMsgBarService } from '../../../../utils/test-mocks';
 import { CustomMatDialogService } from '../../../../services/custom-mat-dialog.service';
+import { MsgBarService } from '../../../../services/msg-bar.service';
 
 describe('WalletDetailComponent', () => {
   let component: WalletDetailComponent;
@@ -23,9 +24,9 @@ describe('WalletDetailComponent', () => {
       schemas: [ NO_ERRORS_SCHEMA ],
       providers: [
         { provide: WalletService, useClass: MockWalletService },
-        { provide: MatSnackBar, useClass: MockMatSnackBar },
         { provide: TranslateService, useClass: MockTranslateService },
-        { provide: CustomMatDialogService, useClass: MockCustomMatDialogService }
+        { provide: CustomMatDialogService, useClass: MockCustomMatDialogService },
+        { provide: MsgBarService, useClass: MockMsgBarService },
       ]
     }).compileComponents();
   }));

--- a/src/app/components/pages/wallets/wallet-detail/wallet-detail.component.ts
+++ b/src/app/components/pages/wallets/wallet-detail/wallet-detail.component.ts
@@ -1,6 +1,5 @@
 import { Component, Input, OnDestroy } from '@angular/core';
 import { MatDialogConfig } from '@angular/material/dialog';
-import { MatSnackBar, MatSnackBarConfig } from '@angular/material';
 import { TranslateService } from '@ngx-translate/core';
 import { Observable } from 'rxjs/Observable';
 
@@ -12,6 +11,7 @@ import { Subscription, ISubscription } from 'rxjs/Subscription';
 import { WalletOptionsComponent, WalletOptionsResponses } from './wallet-options/wallet-options.component';
 import { CustomMatDialogService } from '../../../../services/custom-mat-dialog.service';
 import { config } from '../../../../app.config';
+import { MsgBarService } from '../../../../services/msg-bar.service';
 
 @Component({
   selector: 'app-wallet-detail',
@@ -30,12 +30,12 @@ export class WalletDetailComponent implements OnDestroy {
   constructor(
     private walletService: WalletService,
     private dialog: CustomMatDialogService,
-    private snackBar: MatSnackBar,
-    private translateService: TranslateService
+    private translateService: TranslateService,
+    private msgBarService: MsgBarService,
   ) {}
 
   ngOnDestroy() {
-    this.snackBar.dismiss();
+    this.msgBarService.hide();
     this.removeUnlockSubscription();
     this.removeSlowInfoSubscription();
   }
@@ -131,9 +131,7 @@ export class WalletDetailComponent implements OnDestroy {
 
   private addNewAddress() {
     if (this.creatingAddress === true) {
-      const snackBarConfig = new MatSnackBarConfig();
-      snackBarConfig.duration = 5000;
-      this.snackBar.open(this.translateService.instant('wallet.already-adding-address-error'), null, snackBarConfig);
+      this.msgBarService.showError('wallet.already-adding-address-error');
 
       return;
     }
@@ -160,10 +158,7 @@ export class WalletDetailComponent implements OnDestroy {
     this.showSlowMobileInfo = false;
     this.removeSlowInfoSubscription();
     this.creatingAddress = false;
-
-    const snackBarConfig = new MatSnackBarConfig();
-    snackBarConfig.duration = 5000;
-    this.snackBar.open(error.message, null, snackBarConfig);
+    this.msgBarService.showError(error.message);
   }
 
   private removeUnlockSubscription() {

--- a/src/app/services/msg-bar.service.spec.ts
+++ b/src/app/services/msg-bar.service.spec.ts
@@ -1,0 +1,15 @@
+import { TestBed, inject } from '@angular/core/testing';
+
+import { MsgBarService } from './msg-bar.service';
+
+describe('MsgBarService', () => {
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [MsgBarService],
+    });
+  });
+
+  it('should be created', inject([MsgBarService], (service: MsgBarService) => {
+    expect(service).toBeTruthy();
+  }));
+});

--- a/src/app/services/msg-bar.service.ts
+++ b/src/app/services/msg-bar.service.ts
@@ -1,0 +1,76 @@
+import { Injectable, NgZone } from '@angular/core';
+import { MsgBarConfig, MsgBarComponent, MsgBarIcons, MsgBarColors } from '../components/layout/msg-bar/msg-bar.component';
+import { parseResponseMessage } from '../utils/errors';
+import { ISubscription } from 'rxjs/Subscription';
+import { Observable } from 'rxjs/Observable';
+
+@Injectable()
+export class MsgBarService {
+
+  private timeSubscription: ISubscription;
+
+  private msgBarComponentInternal: MsgBarComponent;
+  set msgBarComponent(value: MsgBarComponent) {
+    this.msgBarComponentInternal = value;
+  }
+
+  constructor(
+    private _ngZone: NgZone,
+  ) {}
+
+  show(config: MsgBarConfig) {
+    if (this.msgBarComponentInternal) {
+      this.msgBarComponentInternal.config = config;
+      this.msgBarComponentInternal.show();
+    }
+  }
+
+  hide() {
+    if (this.msgBarComponentInternal) {
+      this.msgBarComponentInternal.hide();
+    }
+  }
+
+  showError(body: string, duration = 20000) {
+    const config = new MsgBarConfig();
+    config.text = parseResponseMessage(body);
+    config.title = 'errors.error';
+    config.icon = MsgBarIcons.Error;
+    config.color = MsgBarColors.Red;
+
+    this.show(config);
+    this.setTimer(duration);
+  }
+
+  showWarning(body: string, duration = 20000) {
+    const config = new MsgBarConfig();
+    config.text = parseResponseMessage(body);
+    config.title = 'common.warning';
+    config.icon = MsgBarIcons.Warning;
+    config.color = MsgBarColors.Yellow;
+
+    this.show(config);
+    this.setTimer(duration);
+  }
+
+  showDone(body: string, duration = 10000) {
+    const config = new MsgBarConfig();
+    config.text = body;
+    config.title = 'common.success';
+    config.icon = MsgBarIcons.Done;
+    config.color = MsgBarColors.Green;
+
+    this.show(config);
+    this.setTimer(duration);
+  }
+
+  private setTimer(duration = 10000) {
+    if (this.timeSubscription) {
+      this.timeSubscription.unsubscribe();
+    }
+
+    this._ngZone.runOutsideAngular(() => {
+      this.timeSubscription = Observable.of(1).delay(duration).subscribe(() => this._ngZone.run(() => this.hide()));
+    });
+  }
+}

--- a/src/app/utils/test-mocks.ts
+++ b/src/app/utils/test-mocks.ts
@@ -172,9 +172,13 @@ export class MockBlockchainService {
   }
 }
 
-export class MockMatSnackBar {
-  dismiss() {
-  }
+export class MockMsgBarService {
+  set msgBarComponent(value) { }
+  show() { }
+  hide() { }
+  showError(body: string, duration = 20000) { }
+  showWarning(body: string, duration = 20000) { }
+  showDone(body: string, duration = 10000) { }
 }
 
 export class MockTranslateService {

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -6,10 +6,13 @@
     "load": "Load",
     "address": "Address",
     "close": "Close",
-    "slow-on-mobile": "Please wait. This process may take a minute or more on some mobile devices and slow PCs."
+    "slow-on-mobile": "Please wait. This process may take a minute or more on some mobile devices and slow PCs.",
+    "success": "Success",
+    "warning": "Warning"
   },
 
   "errors": {
+    "error": "Error",
     "fetch-version": "Unable to fetch latest release version from Github",
     "incorrect-password": "Incorrect password",
     "api-disabled": "API disabled",
@@ -168,7 +171,8 @@
       "select-coin": "Select coin",
       "unconventional-seed-title": "Possible error",
       "unconventional-seed-text": "You introduced an unconventional seed. If you did it for any special reason, you can continue (only recommended for advanced users). However, if your intention is to use a normal system seed, you must delete all the additional text and special characters.",
-      "unconventional-seed-check": "Continue with the unconventional seed."
+      "unconventional-seed-check": "Continue with the unconventional seed.",
+      "wallet-created": "The wallet has been added to the list."
     },
 
     "scan": {
@@ -243,7 +247,8 @@
     "advanced": "Advanced",
     "select-wallet": "Select Wallet",
     "recipient-address": "Recipient address",
-    "your-note": "Your note here"
+    "your-note": "Your note here",
+    "sent": "Transaction successfully sent."
   },
 
   "tx": {
@@ -330,6 +335,7 @@
       "node-version": "Node version",
       "last-block": "Last block",
       "hours-burn-rate": "Hours burn rate",
+      "url-changed": "The URL has been changed.",
 
       "confirmation" : {
         "title": "Security",

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -471,14 +471,6 @@ Responsive design
   }
 }
 
-.fix-error-position {
-  @media (max-width: $max-small-width) {
-    .cdk-global-overlay-wrapper[style*="align-items: flex-end;"] > div {
-      margin-bottom: $mobile-nav-bar-height !important;
-    }
-  }
-}
-
 .coin-selector-container {
   display: inline-block;
   margin-left: 5px;


### PR DESCRIPTION
Fixes #521

Changes:
- Now the GUI uses a custom snackbar, instead of the one provided by Angular Material. This PR includes the changes made in https://github.com/skycoin/skycoin/pull/2408 and https://github.com/skycoin/skycoin/pull/2455 but the code was adapted to work in the web wallet, including compatibility with the responsive design (responsive design was one of the main motivations for creating a new snackbar).
