### PR TITLE
Show the USD price using 2 decimals

### DIFF
--- a/src/app/components/layout/header/header.component.ts
+++ b/src/app/components/layout/header/header.component.ts
@@ -159,7 +159,7 @@ export class HeaderComponent implements OnInit, OnDestroy {
   private calculateBalance() {
     if (this.price) {
       const balance = this.coins.multipliedBy(this.price).toNumber();
-      this.balance = '$' + balance.toFixed(2) + ' ($' + (Math.round(this.price * 100) / 100) + ')';
+      this.balance = '$' + balance.toFixed(2) + ' ($' + (Math.round(this.price * 100) / 100).toFixed(2) + ')';
     }
   }
 


### PR DESCRIPTION
Changes:
- Now the current USD price shown on the header always has 2 decimals.
