### PR TITLE
Fix problems with the CSP

### DIFF
--- a/docker/images/nginx.conf
+++ b/docker/images/nginx.conf
@@ -43,7 +43,7 @@ http
     # ssl_certificate /etc/nginx/ssl/server.crt;
     # ssl_certificate_key /etc/nginx/ssl/server.key;
 
-    add_header Content-Security-Policy "default-src 'self'; worker-src 'self' blob:; connect-src 'self' https://node.skycoin.net https://api.coinpaprika.com; img-src 'self' 'unsafe-inline' data:; style-src 'self' 'unsafe-inline'; object-src 'none'; form-action 'none'; frame-ancestors 'none'; block-all-mixed-content; base-uri 'self'";
+    add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-eval'; connect-src 'self' https://node.skycoin.net https://api.coinpaprika.com; img-src 'self' 'unsafe-inline' data:; style-src 'self' 'unsafe-inline'; object-src 'none'; form-action 'none'; frame-ancestors 'none'; block-all-mixed-content; base-uri 'self'";
 
     location ~ \.css
     {

--- a/electron/server.go
+++ b/electron/server.go
@@ -31,7 +31,7 @@ var (
 
 // ContentSecurityPolicy csp header in http response
 const ContentSecurityPolicy = "default-src 'self'" +
-	"; worker-src 'self' blob:" +
+	"; script-src 'self' 'unsafe-eval'" +
 	"; connect-src *" +
 	"; img-src 'self' 'unsafe-inline' data:" +
 	"; style-src 'self' 'unsafe-inline'" +

--- a/src/assets/scripts/index-scripts.js
+++ b/src/assets/scripts/index-scripts.js
@@ -1,0 +1,4 @@
+window.removeSplash = function() {
+  var element = document.getElementById('splashScreen');
+  element.parentNode.removeChild(element);
+}

--- a/src/index.html
+++ b/src/index.html
@@ -41,12 +41,7 @@
     @-webkit-keyframes splash-spin { 100% { -webkit-transform: rotate(360deg); } }
     @keyframes splash-spin { 100% { -moz-transform: rotate(360deg); -webkit-transform: rotate(360deg); transform: rotate(360deg); } }
   </style>
-  <script>
-    window.removeSplash = function() {
-      var element = document.getElementById('splashScreen');
-      element.parentNode.removeChild(element);
-    }
-  </script>
+  <script src="/assets/scripts/index-scripts.js"></script>
   <script src="/assets/scripts/wasm_exec.js"></script>
 </head>
 <body>


### PR DESCRIPTION
Fixes #580 

Changes:
- The inline script that was added to `index.html` was moved to a file, to stop violating the CSP.

- The `worker-src` rule was removed from the CSP, as the web worker used by the app was replaced by a wasm file, so the rule is not longer needed.

- The `script-src` rule was added to the CSP, because the previous value (inherited from `default-src`) prevented the wasm file from being used in Safari and Chrome (affecting the Electron version). The problem is known by the involved parties, but apparently there is no better solution for now. There is more info about the problem in https://github.com/WebAssembly/content-security-policy/blob/master/proposals/CSP.md

