### PR TITLE
Run npm install with --unsafe-perm in Dockerfile

### DIFF
--- a/docker/images/Dockerfile
+++ b/docker/images/Dockerfile
@@ -5,7 +5,7 @@ COPY . /usr/src/skycoin-web
 WORKDIR /usr/src/skycoin-web
 
 RUN npm install -g @angular/cli \
-    && npm install \
+    && npm install --unsafe-perm \
     && npm run build
 
 FROM nginx:alpine


### PR DESCRIPTION
Changes:

Npm install in the first stage of docker building will report error of:

```
npm WARN lifecycle desktopwallet@0.0.0~prepare: cannot run in wd desktopwallet@0.0.0 npm run snyk-protect (wd=/usr/src/skycoin-web)

```

which will make snyk-protect fail to do the patches.